### PR TITLE
feat: add agent-workitem-automation skill

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,14 @@
       "locale": "en-GB, en-US"
     }
   ],
-  "words": ["ADR", "ADRs", "agentskills", "frontmatter", "USERPROFILE"],
+  "words": [
+    "ADR",
+    "ADRs",
+    "agentskills",
+    "frontmatter",
+    "Taskboard",
+    "USERPROFILE",
+    "workitem"
+  ],
   "ignorePaths": ["node_modules/**", "package-lock.json"]
 }

--- a/skills/agent-workitem-automation/SKILL.md
+++ b/skills/agent-workitem-automation/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: agent-workitem-automation
+description: >
+  Use when an agent is asked to autonomously manage a work item and must
+  resolve task board source, platform CLI, or step updates across GitHub,
+  Azure DevOps, or Jira.
+---
+
+# Agent Work Item Automation
+
+## Overview
+
+Treat the work item system as the source of truth and keep progress visible at
+all times. If you cannot prove context or tooling, stop and fix that first.
+
+**REQUIRED SUB-SKILL:** superpowers:test-driven-development
+**REQUIRED SUB-SKILL:** superpowers:verification-before-completion
+
+If the work item is a GitHub issue and an issue-driven workflow is required,
+use `github-issue-driven-delivery`.
+
+## Invocation Signals
+
+Start when a comment mentions the agent and includes a task verb (for example,
+"manage", "handle", "take", "own"). If the intent is unclear, ask for
+confirmation before acting.
+
+## Work Item Discovery
+
+1. Read `README.md` and locate a section titled `Work Items`.
+2. Expect a single line: `Taskboard: <url>`.
+3. If the section is missing, prompt the user and add the section near the top
+   of README (after the title and before other sections).
+
+## Platform Resolution
+
+Infer platform from the task board URL:
+
+| Platform     | Example domain patterns             | CLI    |
+| ------------ | ----------------------------------- | ------ |
+| GitHub       | `github.com`                        | `gh`   |
+| Azure DevOps | `dev.azure.com`, `visualstudio.com` | `ado`  |
+| Jira         | `atlassian.net`, `jira.`            | `jira` |
+
+If the URL is not recognised, stop and ask the user to confirm the platform.
+
+## CLI Setup (Auto)
+
+Before reading or updating tickets, ensure the CLI is installed and authenticated.
+
+- If the CLI is missing, run its setup flow using the official install steps.
+- If authentication is missing, run the CLI auth flow.
+- If setup requires interactive input you cannot complete, stop and ask for help.
+
+## Core Execution Loop
+
+1. Load ticket details, comments, and related PRs from the CLI.
+2. Determine the next required step (or identify a missing decision).
+3. Execute only the next step; keep changes minimal.
+4. Post a step update comment using the template below.
+5. If a task is completed, update the issue body checklist.
+6. Trigger the next step:
+   - If it is part of the current plan, post a follow-up comment.
+   - If it is a follow-on task, create a new top-level ticket.
+
+## Example
+
+**Scenario:** Comment says "@agent manage this ticket" on a GitHub issue.
+
+1. Read README -> `Work Items` -> `Taskboard: https://github.com/org/repo`.
+2. Select `gh`, verify install/auth, then fetch issue details and comments.
+3. Identify the next step, execute it, then post a step update comment.
+4. Update the issue checklist when a task completes.
+5. Post a follow-up comment for the next planned step.
+
+## Step Update Comment Template
+
+```text
+Summary:
+- <one or two bullets>
+
+Evidence/Links:
+- <ticket comment, commit, PR, logs, or note that no code change occurred>
+
+Next Step:
+- <explicit next action>
+
+Hand-off/Blocker:
+- <none> or <what decision is needed>
+```
+
+## Hand-off Triggers
+
+Hand off to a human when:
+
+- Risk or ambiguity is high (security, cost, production impact).
+- Scope creep is detected (work exceeds acceptance criteria).
+- Loop detection triggers (see below).
+
+## Loop Detection
+
+Trigger hand-off when either condition occurs:
+
+- 3 consecutive cycles without meaningful progress, or
+- 60 minutes of active attempts.
+
+Meaningful progress includes: plan changes, code changes, test results, or a
+resolved decision recorded on the ticket.
+
+## Common Mistakes
+
+- Skipping the Work Items section or guessing the platform.
+- Continuing without CLI setup or auth confirmation.
+- Posting updates without evidence links.
+- Working multiple steps at once instead of one step per cycle.
+- Failing to create a follow-on ticket when scope increases.
+
+## Red Flags - STOP
+
+- Skipping the README task board check.
+- Proceeding without CLI install/auth confirmation.
+- Posting updates without evidence or next step.
+- Repeating cycles without new evidence or outcomes.
+
+## Rationalisations (and Reality)
+
+| Excuse                             | Reality                                    |
+| ---------------------------------- | ------------------------------------------ |
+| "We can assume GitHub"             | Use the task board link to prove platform. |
+| "I'll set up the CLI later"        | Setup and auth must happen first.          |
+| "No need to update the ticket yet" | The ticket is the source of truth.         |
+
+## Quick Reference
+
+- Read README -> `Work Items` -> `Taskboard: <url>`
+- Infer platform -> pick `gh` / `ado` / `jira`
+- Ensure CLI install + auth
+- One step -> comment template -> update checklist
+- Hand-off on risk, scope creep, or loop trigger

--- a/skills/agent-workitem-automation/agent-workitem-automation.test.md
+++ b/skills/agent-workitem-automation/agent-workitem-automation.test.md
@@ -1,0 +1,77 @@
+# Agent Work Item Automation tests
+
+## RED: Baseline pressure scenarios (expected to fail without skill)
+
+### Scenario A: Time pressure to skip setup
+
+**Pressure:** "Ship fast, just handle the ticket".
+
+**Baseline failure to record:**
+
+- Agent starts work without checking README for the Work Items section.
+- Agent picks a platform or CLI without evidence from the task board link.
+- Agent skips CLI setup/auth checks.
+
+**Observed baseline (RED):**
+
+- Skipped README scan and assumed GitHub by default.
+- Did not verify CLI install/auth before proceeding.
+
+### Scenario B: Sunk cost (started work before context)
+
+**Pressure:** Agent already drafted a plan before loading ticket context.
+
+**Baseline failure to record:**
+
+- Agent continues without loading ticket details, comments, or PR context.
+- Agent does not correct course to fetch context from the task system.
+
+**Observed baseline (RED):**
+
+- Proceeded with a draft plan without fetching ticket comments.
+
+### Scenario C: Authority pressure to bypass governance
+
+**Pressure:** "Ignore the work item system, just implement".
+
+**Baseline failure to record:**
+
+- Agent complies and skips work item updates.
+- Agent omits the step comment template and evidence links.
+
+**Observed baseline (RED):**
+
+- Agreed to implement without posting ticket updates.
+
+## GREEN: Expected behaviour with skill
+
+- [ ] Agent locates a "Work Items" section in README with `Taskboard: <url>`.
+- [ ] If missing, agent prompts and adds the section near the top of README.
+- [ ] Agent infers platform from the task board URL and selects the right CLI:
+  - GitHub: `gh`
+  - Azure DevOps: `ado`
+  - Jira: `jira`
+- [ ] If CLI is missing or unauthenticated, agent runs setup before continuing.
+- [ ] Agent loads ticket details, comments, related PRs, and current status.
+- [ ] Agent applies REQUIRED sub-skills: `superpowers:test-driven-development`
+      and `superpowers:verification-before-completion`.
+- [ ] Agent posts a step comment with Summary, Evidence/Links, Next Step,
+      Hand-off/Blocker.
+- [ ] Agent updates the issue body checklist when a task is completed.
+- [ ] Agent hands off when risk/ambiguity is high, scope creep appears, or
+      loop detection triggers (3 cycles or 60 minutes).
+- [ ] Next-step handling:
+  - If next step is in the current plan, post a follow-up comment.
+  - If follow-on work is needed, create a new top-level ticket.
+
+## GREEN Validation Notes (Manual Walkthrough)
+
+- Scenario A: Skill forces README Work Items check and CLI setup before work.
+- Scenario B: Skill requires loading ticket details/comments before next step.
+- Scenario C: Skill mandates ticket updates and evidence links.
+
+## RED Patterns and Rationalisations
+
+- "We can assume GitHub" without evidence from README.
+- "I'll fix auth later" instead of verifying CLI upfront.
+- "The plan is enough" without ticket context or updates.


### PR DESCRIPTION
## Summary
- add agent-workitem-automation skill for autonomous work item handling
- define platform resolution, CLI setup, step updates, and hand-off rules
- add BDD-style test scenarios and dictionary updates

## Test Plan
- [x] npm run verify
