### PR TITLE
docs: require taskboard issue for changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,10 @@
 Agents must follow the standards in `README.md` before taking any action.
 These rules tighten the workflow for autonomous execution.
 
+- **No changes without a Taskboard issue.** All non-read-only work must be tied
+  to a Taskboard issue. Read-only work and reviews are allowed without a ticket.
+- **Traceability required.** Every change must be traceable to a Taskboard
+  issue; create one if it does not exist.
 - **Feature branch only.** If you are on `main`, stop and create a feature
   branch before any edits or commits. Do not commit on `main`.
 - **Skills-first enforcement.** Bootstrap, load skills, and follow process

--- a/docs/plans/2026-01-04-taskboard-required-changes.md
+++ b/docs/plans/2026-01-04-taskboard-required-changes.md
@@ -1,0 +1,18 @@
+# Taskboard Enforcement (BDD Checklist)
+
+## RED: Failing checklist before edits
+
+- [ ] AGENTS.md forbids repository changes without a Taskboard issue.
+- [ ] AGENTS.md allows read-only operations and reviews without a ticket.
+- [ ] github-issue-driven-delivery requires a Taskboard issue before changes.
+
+**Failure notes:**
+
+- AGENTS.md does not require an issue before changes.
+- github-issue-driven-delivery lacks a mandatory taskboard requirement.
+
+## GREEN: Checklist after edits
+
+- [x] AGENTS.md forbids repository changes without a Taskboard issue.
+- [x] AGENTS.md allows read-only operations and reviews without a ticket.
+- [x] github-issue-driven-delivery requires a Taskboard issue before changes.

--- a/skills/github-issue-driven-delivery/SKILL.md
+++ b/skills/github-issue-driven-delivery/SKILL.md
@@ -22,23 +22,26 @@ Use GitHub issues as the source of truth for planning, approvals, execution evid
 ## Core Workflow
 
 1. Announce the skill and why it applies; confirm gh availability.
-2. Confirm the target issue and keep all work tied to it.
-3. Create a plan, commit it as WIP, and post the plan link in an issue comment for approval.
-4. Stop and wait for an explicit approval comment containing the word "approved" before continuing.
-5. Keep all plan discussions and decisions in issue comments.
-6. After approval, add issue sub-tasks for every plan task and keep a 1:1 mapping by name.
-7. Execute each task and attach evidence and reviews to its sub-task.
-8. Stop and wait for explicit approval before closing each sub-task.
-9. Close sub-tasks only after approval and mark the plan task complete.
-10. Require each persona to post a separate review comment in the issue thread using superpowers:receiving-code-review.
-11. Summarize persona recommendations in the plan and link to the individual review comments.
-12. Add follow-up fixes as new tasks in the same issue.
-13. Create a new issue for next steps with implementation, test detail, and acceptance criteria.
-14. Open a PR after delivery is accepted.
-15. If a PR exists, link the PR and issue, monitor PR comment threads, and address PR feedback before completion.
-16. If changes occur after review feedback, re-run BDD validation and update evidence before claiming completion.
-17. If BDD assertions change, require explicit approval before updating them.
-18. When all sub-tasks are complete and all verification tasks are complete and
+2. Confirm a Taskboard issue exists for the work. If none exists, create the
+   issue before making any changes. Read-only work and reviews are allowed
+   without a ticket.
+3. Confirm the target issue and keep all work tied to it.
+4. Create a plan, commit it as WIP, and post the plan link in an issue comment for approval.
+5. Stop and wait for an explicit approval comment containing the word "approved" before continuing.
+6. Keep all plan discussions and decisions in issue comments.
+7. After approval, add issue sub-tasks for every plan task and keep a 1:1 mapping by name.
+8. Execute each task and attach evidence and reviews to its sub-task.
+9. Stop and wait for explicit approval before closing each sub-task.
+10. Close sub-tasks only after approval and mark the plan task complete.
+11. Require each persona to post a separate review comment in the issue thread using superpowers:receiving-code-review.
+12. Summarize persona recommendations in the plan and link to the individual review comments.
+13. Add follow-up fixes as new tasks in the same issue.
+14. Create a new issue for next steps with implementation, test detail, and acceptance criteria.
+15. Open a PR after delivery is accepted.
+16. If a PR exists, link the PR and issue, monitor PR comment threads, and address PR feedback before completion.
+17. If changes occur after review feedback, re-run BDD validation and update evidence before claiming completion.
+18. If BDD assertions change, require explicit approval before updating them.
+19. When all sub-tasks are complete and all verification tasks are complete and
     the PR is approved ensure that the source Issue is closed with the PR and
     the source branch is deleted
 

--- a/skills/github-issue-driven-delivery/github-issue-driven-delivery.test.md
+++ b/skills/github-issue-driven-delivery/github-issue-driven-delivery.test.md
@@ -32,6 +32,7 @@ Without the skill, a typical response rationalizes skipping issue workflow steps
 ## Assertions (Expected to Fail Until Skill Exists)
 
 - gh is listed as a prerequisite in the skill.
+- A Taskboard issue exists before any changes (read-only and reviews excluded).
 - The workflow requires committing a WIP plan and posting a plan-link comment before execution.
 - Plan approval is collected via an issue comment before sub-tasks are created.
 - Each plan task maps to an issue sub-task (task list or sub-issue).


### PR DESCRIPTION
## Summary
- require a Taskboard issue before any repo changes in AGENTS
- add mandatory Taskboard requirement to github-issue-driven-delivery
- extend BDD assertions and record TDD checklist

## Test Plan
- [x] npm run verify
