### PR TITLE
feat: enforce issue closure after all scope delivered

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ These rules tighten the workflow for autonomous execution.
 - **PR close policy.** Follow the README merge policy (rebase, then choose
   squash or fast-forward only) and use a Conventional Commit squash message
   with ticket footer when appropriate.
+- **Issue closure after scope complete.** When all in-scope work for an issue is
+  delivered (all required PRs merged), post final evidence comment and close the
+  issue. If issue requires multiple PRs, keep open until all scope delivered or
+  remaining work moved to new ticket. Do not leave issues open after all work complete.
 
 ## Bootstrap (First-Time Setup)
 

--- a/skills/agent-workitem-automation/SKILL.md
+++ b/skills/agent-workitem-automation/SKILL.md
@@ -129,12 +129,16 @@ Prefer non-interactive CLI usage in CI. Examples:
 
 ## Delivery Completion (Autonomous)
 
-When all steps in the current plan are complete:
+When all steps in the current plan are complete and all required PRs are merged:
 
 1. Verify completion using `superpowers:verification-before-completion`.
 2. Post a final update comment with evidence and completion summary.
 3. Ensure the taskboard issue is updated with completion evidence.
-4. Close the work item if acceptance criteria are met and no blockers remain.
+4. Close the work item when all in-scope work is delivered, acceptance criteria
+   are met, and no blockers remain.
+5. If issue requires multiple PRs, keep open until all scope delivered or remaining
+   work moved to new ticket.
+6. Do not leave work items open after all work complete.
 
 If any acceptance criteria are unclear or evidence is incomplete, hand off to a
 human instead of closing.

--- a/skills/issue-driven-delivery/SKILL.md
+++ b/skills/issue-driven-delivery/SKILL.md
@@ -83,8 +83,10 @@ and Jira examples.
 18. If changes occur after review feedback, re-run BDD validation and update evidence before claiming completion.
 19. If BDD assertions change, require explicit approval before updating them.
 20. When all sub-tasks are complete and all verification tasks are complete and
-    the PR is approved ensure that the source work item is closed with the PR and
-    the source branch is deleted
+    all required PRs for the issue scope are merged, post final evidence comment
+    to the source work item, close it, and delete merged branches. If issue
+    requires multiple PRs, keep open until all scope delivered or remaining work
+    moved to new ticket. Do not leave work items open after all work complete.
 
 ## Evidence Requirements
 


### PR DESCRIPTION
## Summary

Implements issue #39 - Enforces closing Taskboard issues when all in-scope work is delivered (handles multi-PR issues correctly).

## Changes

### AGENTS.md
- **Added:** "Issue closure after scope complete" rule
- **Key point:** Close when "all in-scope work delivered (all required PRs merged)"
- **Multi-PR handling:** Keep open until all scope delivered or moved to new ticket
- **Prohibition:** "Do not leave issues open after all work complete"

### issue-driven-delivery skill
- **Updated step 20:** Close when "all required PRs for the issue scope are merged"
- **Multi-PR guidance:** Keep open until all scope delivered or moved to new ticket
- **Prohibition:** Don't leave work items open after completion

### agent-workitem-automation skill
- **Updated:** "Delivery Completion" specifies "all required PRs are merged"
- **Added step 5:** Multi-PR handling (keep open until all scope complete)
- **Added step 6:** Explicit prohibition against leaving completed work items open

## Verification Against Acceptance Criteria

### ✅ AGENTS.md requires closing issues after scope complete with evidence
- Line 27-30: New rule added
- Explicit: "When all in-scope work for an issue is delivered (all required PRs merged), post final evidence comment and close"
- Multi-PR: "If issue requires multiple PRs, keep open until all scope delivered"

### ✅ issue-driven-delivery includes close-out step
- Line 85-89: Updated to specify "all required PRs for the issue scope are merged"
- Handles multi-PR scenarios correctly
- Prohibits leaving work items open after completion

### ✅ agent-workitem-automation includes close-out step
- Line 132: Header updated to "all required PRs are merged"
- Lines 137-141: Complete close-out process with multi-PR handling
- Explicit prohibition against leaving work items open

## Rationale

**Problem:** Issues could be left open after work completes, or incorrectly closed after first PR when multiple PRs needed.

**Solution:** Explicit requirement to close when "all in-scope work delivered" ensures:
1. Single-PR issues close promptly after merge
2. Multi-PR issues stay open until all scope delivered
3. Option to move remaining work to new ticket before closing
4. Final evidence documented for complete audit trail
5. No orphaned open issues in backlog

**Handles correctly:**
- ✅ Single PR → Close after merge
- ✅ Multiple PRs → Keep open until all merged
- ✅ Scope change → Move remaining work to new ticket, then close
- ✅ Evidence → Require final comment before closing

**Process followed:**
- ✅ Created feature branch before starting
- ✅ Used TodoWrite to track all tasks
- ✅ User feedback incorporated (multi-PR scenario)
- ✅ Applied broken-window pre-completion checklist

Resolves #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>