### PR TITLE
fix(workflow): prevent direct commits to main branch

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,16 @@
+# Prevent direct commits to main branch
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" = "main" ]; then
+  echo "❌ ERROR: Direct commits to main are not allowed"
+  echo "📋 Required workflow:"
+  echo "   1. Create feature branch: git checkout -b feat/issue-N-description"
+  echo "   2. Commit changes to feature branch"
+  echo "   3. Push feature branch: git push -u origin feat/issue-N-description"
+  echo "   4. Create PR: gh pr create"
+  echo "   5. Merge PR after review"
+  echo ""
+  echo "ℹ️  To commit to main (emergency only), use: git commit --no-verify"
+  exit 1
+fi
+
 npx lint-staged

--- a/skills/issue-driven-delivery/SKILL.md
+++ b/skills/issue-driven-delivery/SKILL.md
@@ -124,10 +124,11 @@ and Jira examples.
    7b. Set work item state to `implementation`. If work item has `blocked` label,
    verify approval comment exists. If approved, remove `blocked` label and proceed.
    If not approved, stop with error.
-   7c. Self-assign when ready to implement (Developer recommended). If work item
-   has `blocked` label, verify approval comment exists. If approved, remove
-   `blocked` label and proceed. If not approved, stop with error showing
-   blocking reason.
+   7c. Self-assign when ready to implement (Developer recommended). **Create feature
+   branch from main:** `git checkout -b feat/issue-N-description`. All implementation
+   work must be done on feature branch, not main. If work item has `blocked` label,
+   verify approval comment exists. If approved, remove `blocked` label and proceed.
+   If not approved, stop with error showing blocking reason.
 8. Execute each task and attach evidence and reviews to its sub-task.
    8a. When all sub-tasks complete, unassign yourself to signal implementation complete.
    8b. Set work item state to `verification`. If work item has `blocked` label,
@@ -243,6 +244,7 @@ gh issue edit 30 --add-assignee @me
 - Proceeding with blocked work without approval comment (bypasses blocked enforcement).
 - Creating circular dependencies without resolution plan (creates deadlock).
 - Blocking original work item by its own follow-up tasks (incorrect dependency direction).
+- Committing directly to main instead of feature branch (violates GitHub Flow, bypasses PR review).
 
 ## Red Flags - STOP
 
@@ -256,6 +258,7 @@ gh issue edit 30 --add-assignee @me
 - "This blocking task can wait until later." (violates priority inheritance)
 - "I'll pick this P3 ticket instead of that P1." (violates priority order)
 - "The blocked label doesn't apply to me." (bypasses blocked enforcement)
+- "I'll just commit to main this time." (bypasses PR review process, violates GitHub Flow)
 
 ## Rationalizations (and Reality)
 


### PR DESCRIPTION
## Summary

Implements preventive measures from workflow violation root cause analysis (docs/retrospectives/2026-01-06-workflow-violation-issue-68.md).

## Changes

**1. Updated Step 7c in SKILL.md**
- Now explicitly requires: **Create feature branch from main:** `git checkout -b feat/issue-N-description`
- All implementation work must be done on feature branch, not main
- Prevents the root cause: starting work without creating feature branch

**2. Added Common Mistake**
- "Committing directly to main instead of feature branch (violates GitHub Flow, bypasses PR review)"

**3. Added Red Flag**
- "I'll just commit to main this time." (bypasses PR review process, violates GitHub Flow)

**4. Added Pre-Commit Hook**
- Blocks direct commits to main branch
- Provides helpful error message with correct workflow steps
- Shows emergency override option (`--no-verify`) for exceptional cases

## Problem Solved

User reported "this keeps occurring" - workflow violations where work was committed directly to main instead of following PR workflow.

**Root Cause:** Workflow documentation didn't explicitly mandate feature branch creation, and there was no technical guard rail to prevent direct commits to main.

**Solution:** Make branch discipline explicit in documentation and enforce with pre-commit hook.

## Test Plan

- [x] Step 7c updated with feature branch requirement
- [x] Common Mistake added
- [x] Red Flag added  
- [x] Pre-commit hook added and tested (blocks commits to main)
- [x] Committed on feature branch (this PR proves the fix works)

## Impact

- ✅ Prevents future workflow violations
- ✅ Makes branch discipline explicit, not implicit
- ✅ Technical enforcement via pre-commit hook
- ✅ Clear guidance when violation is attempted

Related: #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>