### PR TITLE
feat(docs): add frontmatter standard for role/persona documents

### DIFF
--- a/docs/roles/README.md
+++ b/docs/roles/README.md
@@ -31,12 +31,12 @@ model: balanced # Task-based model tier
 
 Task-based values that map to platform-specific models:
 
-| Value       | Use Case                                                   | Claude                | OpenAI      |
-| ----------- | ---------------------------------------------------------- | --------------------- | ----------- |
-| `reasoning` | Complex analysis, architecture design, security compliance | opus, claude-sonnet-4 | o3, gpt-4.1 |
-| `balanced`  | Code review, implementation validation, security review    | sonnet                | gpt-4o      |
-| `speed`     | Quick validation, formatting checks, simple lookups        | haiku                 | gpt-4o-mini |
-| `inherit`   | Use caller's model (see below)                             | (varies)              | (varies)    |
+| Value       | Use Case                                                   | Claude     | OpenAI     |
+| ----------- | ---------------------------------------------------------- | ---------- | ---------- |
+| `reasoning` | Complex analysis, architecture design, security compliance | Opus 4.5   | GPT-5.2    |
+| `balanced`  | Code review, implementation validation, security review    | Sonnet 4.5 | GPT-5.1    |
+| `speed`     | Quick validation, formatting checks, simple lookups        | Haiku 4.5  | GPT-5-nano |
+| `inherit`   | Use caller's model (see below)                             | (varies)   | (varies)   |
 
 ### Choosing Model Tiers
 
@@ -73,7 +73,7 @@ description: |
   Use for technical architecture decisions, design reviews, and cross-cutting
   concerns. Validates system design, evaluates trade-offs, and ensures
   architectural consistency.
-model: reasoning # Complex analysis → opus/claude-sonnet-4, o3/gpt-4.1
+model: reasoning # Complex analysis → Opus 4.5, GPT-5.2
 ---
 ```
 

--- a/docs/roles/accessibility-expert.md
+++ b/docs/roles/accessibility-expert.md
@@ -4,7 +4,7 @@ description: |
   Use for accessibility reviews, WCAG compliance validation, and assistive
   technology compatibility. Validates keyboard navigation, screen reader
   support, and inclusive design patterns.
-model: balanced # General development → sonnet, gpt-4o
+model: balanced # General development → Sonnet 4.5, GPT-5.1
 ---
 
 # Accessibility Expert

--- a/docs/roles/agent-skill-engineer.md
+++ b/docs/roles/agent-skill-engineer.md
@@ -4,7 +4,7 @@ description: |
   Use for skill creation reviews, BDD test design, and agent workflow
   optimization. Validates skill clarity, composability, and progressive
   disclosure patterns.
-model: balanced # General development → sonnet, gpt-4o
+model: balanced # General development → Sonnet 4.5, GPT-5.1
 ---
 
 # Agent Skill Engineer

--- a/docs/roles/cloud-architect.md
+++ b/docs/roles/cloud-architect.md
@@ -4,7 +4,7 @@ description: |
   Use for cloud service selection, infrastructure architecture, and cost
   optimization. Validates high availability, disaster recovery, and
   cloud-native design patterns.
-model: reasoning # Complex analysis → opus, o3
+model: reasoning # Complex analysis → Opus 4.5, GPT-5.2
 ---
 
 # Cloud Architect

--- a/docs/roles/devops-engineer.md
+++ b/docs/roles/devops-engineer.md
@@ -4,7 +4,7 @@ description: |
   Use for deployment planning, CI/CD reviews, and operational readiness.
   Validates monitoring, logging, rollback strategies, and infrastructure
   as code practices.
-model: balanced # General development → sonnet, gpt-4o
+model: balanced # General development → Sonnet 4.5, GPT-5.1
 ---
 
 # DevOps Engineer

--- a/docs/roles/documentation-specialist.md
+++ b/docs/roles/documentation-specialist.md
@@ -4,7 +4,7 @@ description: |
   Use for documentation reviews, API documentation validation, and user
   guide quality. Validates clarity, completeness, and documentation
   standards compliance.
-model: balanced # General development → sonnet, gpt-4o
+model: balanced # General development → Sonnet 4.5, GPT-5.1
 ---
 
 # Documentation Specialist

--- a/docs/roles/performance-engineer.md
+++ b/docs/roles/performance-engineer.md
@@ -5,7 +5,7 @@ description: |
   optimization. Validates algorithmic complexity, caching strategies, and
   database query efficiency. For distributed system scalability or complex
   architectural trade-offs, escalate to Technical Architect.
-model: balanced # Implementation-level optimization → sonnet, gpt-4o
+model: balanced # Implementation-level optimization → Sonnet 4.5, GPT-5.1
 ---
 
 # Performance Engineer

--- a/docs/roles/product-owner.md
+++ b/docs/roles/product-owner.md
@@ -4,7 +4,7 @@ description: |
   Use for requirements validation, business logic reviews, and acceptance
   criteria verification. Validates user value, feature scope, and alignment
   with business requirements.
-model: balanced # General development → sonnet, gpt-4o
+model: balanced # General development → Sonnet 4.5, GPT-5.1
 ---
 
 # Product Owner

--- a/docs/roles/qa-engineer.md
+++ b/docs/roles/qa-engineer.md
@@ -4,7 +4,7 @@ description: |
   Use for testing strategy reviews, quality gate definition, and test
   coverage analysis. Validates edge cases, test reliability, and
   overall quality assurance approach.
-model: balanced # General development → sonnet, gpt-4o
+model: balanced # General development → Sonnet 4.5, GPT-5.1
 ---
 
 # QA Engineer

--- a/docs/roles/security-architect.md
+++ b/docs/roles/security-architect.md
@@ -4,7 +4,7 @@ description: |
   Use for security architecture decisions, compliance requirements, and
   threat modelling frameworks. Validates zero-trust principles, security
   boundaries, and regulatory compliance (SOC2, GDPR).
-model: reasoning # Complex analysis → opus, o3
+model: reasoning # Complex analysis → Opus 4.5, GPT-5.2
 ---
 
 # Security Architect

--- a/docs/roles/security-reviewer.md
+++ b/docs/roles/security-reviewer.md
@@ -5,7 +5,7 @@ description: |
   vulnerability checks, and secure coding patterns. Validates authentication,
   authorization, and data protection in code. For architecture-level security,
   threat modelling, or compliance requirements, use Security Architect instead.
-model: balanced # Implementation-level security → sonnet, gpt-4o
+model: balanced # Implementation-level security → Sonnet 4.5, GPT-5.1
 ---
 
 # Security Reviewer

--- a/docs/roles/senior-developer.md
+++ b/docs/roles/senior-developer.md
@@ -4,7 +4,7 @@ description: |
   Use for code quality reviews, implementation patterns, and clean code
   principles. Validates code readability, maintainability, and adherence
   to team conventions.
-model: balanced # General development → sonnet, gpt-4o
+model: balanced # General development → Sonnet 4.5, GPT-5.1
 ---
 
 # Senior Developer

--- a/docs/roles/tech-lead.md
+++ b/docs/roles/tech-lead.md
@@ -4,7 +4,7 @@ description: |
   Use for technical architecture decisions, design reviews, and cross-cutting
   concerns. Validates system design, evaluates trade-offs, and ensures
   architectural consistency across the codebase.
-model: reasoning # Complex analysis → opus, o3
+model: reasoning # Complex analysis → Opus 4.5, GPT-5.2
 ---
 
 # Tech Lead

--- a/docs/roles/technical-architect.md
+++ b/docs/roles/technical-architect.md
@@ -4,7 +4,7 @@ description: |
   Use for enterprise architecture decisions, system integration reviews, and
   major technology selection. Validates architectural patterns, service
   boundaries, and data architecture.
-model: reasoning # Complex analysis → opus, o3
+model: reasoning # Complex analysis → Opus 4.5, GPT-5.2
 ---
 
 # Technical Architect

--- a/docs/roles/ux-expert.md
+++ b/docs/roles/ux-expert.md
@@ -4,7 +4,7 @@ description: |
   Use for user-facing feature reviews, workflow design, and interaction
   patterns. Validates user flows, interface consistency, and feedback
   mechanisms.
-model: balanced # General development → sonnet, gpt-4o
+model: balanced # General development → Sonnet 4.5, GPT-5.1
 ---
 
 # UX Expert


### PR DESCRIPTION
## Summary

- Add YAML frontmatter schema to `docs/roles/README.md` documenting required fields
- Retrofit all 14 role files with `name`, `description`, and `model` frontmatter
- Use task-based model tiers (`reasoning`, `balanced`, `speed`, `inherit`) for cross-platform compatibility
- Include platform-specific model mappings in comments (Claude/OpenAI)

## Model Assignments

| Model Tier | Roles |
|------------|-------|
| `reasoning` | tech-lead, security-architect, technical-architect, cloud-architect |
| `balanced` | All other roles (10 files) |

## Test Plan

- [x] BDD checklist created (RED phase) - all criteria failed before implementation
- [x] Frontmatter schema documented in README.md
- [x] All 14 role files have valid YAML frontmatter
- [x] `model` field uses task-based values with platform examples
- [x] `description` field includes when-to-use guidance
- [x] Linting passes (prettier + markdownlint)
- [x] Existing role content preserved

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)