### PR TITLE
feat(automation): add blocked sync template and documentation (#146)

### DIFF
--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -209,6 +209,8 @@ triggers:
 
 ## Playbook Index
 
+- [blocked-sync.md](blocked-sync.md) - Automatically unblocks dependent issues when blocking
+  issues are closed
 - [conducting-pr-reviews.md](conducting-pr-reviews.md) - GitHub-specific PR review process
   (customized from platform-agnostic skill reference)
 - [duplicate-detection.md](duplicate-detection.md) - Detects potentially duplicate issues

--- a/docs/playbooks/blocked-sync.md
+++ b/docs/playbooks/blocked-sync.md
@@ -1,0 +1,266 @@
+---
+name: blocked-sync
+description: |
+  GitHub Actions workflow that automatically unblocks dependent issues when their blocking
+  issues are closed. Handles multi-blocker scenarios and detects manual/external blocks.
+summary: |
+  1. Workflow triggers when any issue is closed
+  2. Script searches for issues with "Blocked by #N" that have "blocked" label
+  3. If sole blocker: Remove label, post "Auto-unblocked" comment
+  4. If multiple blockers: Post update, keep label with remaining blockers
+  5. Manual blocks (external, approval) are skipped
+triggers:
+  - blocked issue resolved
+  - unblock dependents
+  - blocker closed
+  - auto-unblock
+  - blocked by completed
+  - dependency resolved
+---
+
+# Blocked Status Sync Playbook
+
+## Overview
+
+This playbook describes how to configure and use the blocked status sync workflow,
+which automatically manages the "blocked" label lifecycle as blocking issues are resolved.
+
+## How It Works
+
+```mermaid
+flowchart TD
+    subgraph Trigger["Workflow Trigger"]
+        CLOSE["Issue #100 Closed"]
+    end
+
+    subgraph Detection["Find Dependents"]
+        SEARCH["Search: 'Blocked by #100'"]
+        VERIFY["Verify 'blocked' label exists"]
+        PARSE["Parse blocker list"]
+    end
+
+    subgraph Decision["Determine Action"]
+        SOLE{{"Sole blocker?"}}
+        MANUAL{{"Manual block?"}}
+    end
+
+    subgraph Actions["Take Action"]
+        UNBLOCK["Remove 'blocked' label\nPost: 'Auto-unblocked'"]
+        UPDATE["Post: 'Still blocked by #X, #Y'"]
+        SKIP["Skip - log warning"]
+    end
+
+    CLOSE --> SEARCH
+    SEARCH --> VERIFY
+    VERIFY --> PARSE
+    PARSE --> MANUAL
+    MANUAL -->|Yes| SKIP
+    MANUAL -->|No| SOLE
+    SOLE -->|Yes| UNBLOCK
+    SOLE -->|No| UPDATE
+```
+
+## Blocking Pattern Format
+
+The workflow recognizes these "Blocked by" patterns in issue body or comments:
+
+| Pattern                      | Example                  | Notes                      |
+| ---------------------------- | ------------------------ | -------------------------- |
+| `Blocked by: #N`             | Blocked by: #100         | Standard format with colon |
+| `Blocked by #N`              | Blocked by #100          | Without colon              |
+| `Blocked by: #N, #M, #O`     | Blocked by: #100, #101   | Multiple blockers          |
+| `blocked by #N` (lowercase)  | blocked by #100          | Case-insensitive           |
+| `Blocked by #N (with notes)` | Blocked by #100 (reason) | Notes after are ignored    |
+
+**Required for detection:**
+
+1. Issue must have the `blocked` label
+2. Issue body or comment must contain "Blocked by" pattern with issue number
+
+## Manual Block Keywords
+
+Issues with these keywords in the blocking statement are **NOT** auto-unblocked:
+
+- `waiting for`
+- `external`
+- `approval`
+- `client`
+- `vendor`
+- `third party`
+
+**Example (skipped):**
+
+```text
+Blocked by: #100 (waiting for external approval)
+```
+
+## Configuration
+
+### Step 1: Copy Script
+
+Ensure the unblock script exists at `scripts/issue-driven-delivery/unblock-dependents.sh`.
+
+The script is included in this repository. For other repositories, copy it from:
+`skills/issue-driven-delivery/scripts/unblock-dependents.sh` (if packaged separately).
+
+### Step 2: Copy Workflow
+
+Copy the template from `skills/issue-driven-delivery/templates/sync-blocked-status.yml`
+to `.github/workflows/auto-unblock.yml` (or `sync-blocked-status.yml`).
+
+### Step 3: Verify Permissions
+
+The workflow requires `issues: write` permission. This is set in the template but verify
+your repository allows this permission for Actions.
+
+## Script Usage
+
+The unblock script can also be run manually for testing or maintenance:
+
+```bash
+# Dry-run: See what would happen
+./scripts/issue-driven-delivery/unblock-dependents.sh 100
+
+# Apply changes
+./scripts/issue-driven-delivery/unblock-dependents.sh 100 --apply
+
+# Show dependency graph
+./scripts/issue-driven-delivery/unblock-dependents.sh 100 --graph
+
+# Auto-detect recently closed issues
+./scripts/issue-driven-delivery/unblock-dependents.sh --graph
+```
+
+### Script Options
+
+| Option    | Description                                |
+| --------- | ------------------------------------------ |
+| (number)  | Issue number to process                    |
+| `--apply` | Actually make changes (dry-run by default) |
+| `--graph` | Show dependency graph (ASCII or Mermaid)   |
+| `--help`  | Show help message                          |
+
+### Graph Output
+
+**Terminal (ASCII):**
+
+```text
+Dependency Graph (issues blocked by #100):
+=============================================
+
+  #100 (closed/processing)
+    ├── #101 (will unblock) - Implement feature X
+    ├── #102 (still blocked by #103, #104) - Deploy...
+    └── #105 (will unblock) - Update documentation
+```
+
+**Piped (Mermaid):**
+
+```text
+graph TD
+    100["#100 (closed)"]
+    100 --> 101["#101"]
+    100 --> 102["#102"]
+    100 --> 105["#105"]
+```
+
+## Circular Dependency Detection
+
+The script detects circular dependencies and suggests resolution:
+
+```text
+[WARN] Circular dependency detected: #101 #102 #103 #101
+
+Resolution suggestion based on rework-cost heuristics:
+
+  #101: LOW rework cost
+  #102: MEDIUM rework cost
+  #103: HIGH rework cost
+
+Recommendation: Unblock the issue with LOWEST rework cost first.
+Create a follow-up task for rework after the cycle completes.
+```
+
+### Rework Cost Estimation
+
+| Cost   | Keywords in blocking statement            |
+| ------ | ----------------------------------------- |
+| LOW    | interface, mock, stub, config             |
+| HIGH   | schema, migration, architecture, breaking |
+| MEDIUM | (default)                                 |
+
+## Troubleshooting
+
+### Issue: Dependent not unblocked
+
+**Check 1:** Does the dependent issue have the `blocked` label?
+
+```bash
+gh issue view 101 --json labels --jq '.labels[].name'
+```
+
+**Check 2:** Does the body/comment contain the exact pattern?
+
+```bash
+gh issue view 101 --json body,comments \
+  --jq '([.body] + [.comments[].body]) | .[] | select(test("(?i)blocked by"))'
+```
+
+**Check 3:** Is it a manual block?
+
+Look for keywords: "waiting for", "external", "approval", "client", "vendor".
+
+### Issue: Workflow not triggering
+
+**Check:** Is the workflow file in `.github/workflows/`?
+
+**Check:** Is the trigger correct?
+
+```yaml
+on:
+  issues:
+    types: [closed]
+```
+
+### Issue: Script fails with permission error
+
+**Check:** GitHub token has `issues: write` permission.
+
+**Check:** Script is executable:
+
+```bash
+chmod +x ./scripts/issue-driven-delivery/unblock-dependents.sh
+```
+
+### Issue: False positives in search
+
+The script verifies each search result:
+
+1. Must have `blocked` label
+2. Must have `Blocked by: #N` pattern (not just mentioned)
+
+If false positives occur, check for text that coincidentally matches the pattern.
+
+### Issue: Want to test without changes
+
+Run the script without `--apply`:
+
+```bash
+./scripts/issue-driven-delivery/unblock-dependents.sh 100
+# Shows [DRY-RUN] prefix for all actions
+```
+
+## Integration with Other Workflows
+
+This workflow complements:
+
+- **validate-labels.yml** - Ensures `blocked` label is applied correctly
+- **sync-project-status.yml** - Updates project board when blocked status changes
+- **detect-duplicates.yml** - May find blocked issues as potential duplicates
+
+## See Also
+
+- `skills/issue-driven-delivery/templates/sync-blocked-status.yml` - Template workflow
+- `.github/workflows/auto-unblock.yml` - Installed workflow
+- `scripts/issue-driven-delivery/unblock-dependents.sh` - Core script
+- `docs/playbooks/ticket-lifecycle.md` - Issue state transitions

--- a/skills/issue-driven-delivery/sync-blocked-status.test.md
+++ b/skills/issue-driven-delivery/sync-blocked-status.test.md
@@ -1,0 +1,281 @@
+# sync-blocked-status - BDD Tests
+
+## Overview
+
+Tests for the GitHub Actions workflow that automatically unblocks dependent issues when their
+blocking issues are closed.
+
+**Related Files:**
+
+- `.github/workflows/auto-unblock.yml` - Installed workflow
+- `skills/issue-driven-delivery/templates/sync-blocked-status.yml` - Template workflow
+- `scripts/issue-driven-delivery/unblock-dependents.sh` - Core script
+- `docs/playbooks/blocked-sync.md` - Configuration playbook
+
+## Baseline (No Workflow Present)
+
+### Pressure Scenario 1: Stale Blocked Status
+
+Given blocking issue #A is closed
+When no automatic unblocking exists
+Then dependent issue #B remains labeled "blocked" indefinitely
+And team must manually discover #A was resolved
+And #B delivery is delayed unnecessarily
+
+### Pressure Scenario 2: Incomplete Multi-Blocker Updates
+
+Given issue #C is blocked by #A, #B, #D
+When #A is closed manually
+Then team updates #C to remove #A from blockers
+And team forgets to check if other blockers remain
+And #C is unblocked prematurely OR stays blocked incorrectly
+
+### Pressure Scenario 3: Hidden Dependency Chains
+
+Given complex dependency graph exists
+When multiple blockers close in sequence
+Then manual tracking becomes error-prone
+And blocked issues are forgotten or missed
+And backlog health degrades over time
+
+## Baseline Observations (Simulated)
+
+Without the workflow, typical problems include:
+
+- "I didn't know #A was resolved - #B could have started days ago."
+- "We accidentally unblocked #C but it's still waiting on #D."
+- "Our backlog has issues marked blocked that are no longer actually blocked."
+- "Nobody remembered to update the blocked-by comment when blockers closed."
+
+## Assertions (Workflow Behavior)
+
+### Trigger Assertions
+
+- [ ] Workflow triggers on `issues.closed` event
+- [ ] Workflow does NOT trigger on `issues.opened` event
+- [ ] Workflow does NOT trigger on `issues.labeled` event
+- [ ] Workflow does NOT trigger on `issues.edited` event
+
+### Detection Logic Assertions
+
+- [ ] Script searches for issues with "Blocked by #N" pattern
+- [ ] Script verifies issues have "blocked" label
+- [ ] Script excludes the closed issue itself from results
+- [ ] Script handles case-insensitive "Blocked by" pattern
+- [ ] Script handles comma-separated blocker lists ("Blocked by #1, #2, #3")
+
+### Single Blocker Assertions
+
+- [ ] When sole blocker closes, "blocked" label is removed
+- [ ] Comment "Auto-unblocked: #N completed" is posted
+- [ ] Timestamp is included in unblock comment
+
+### Multi-Blocker Assertions
+
+- [ ] When one of multiple blockers closes, label remains
+- [ ] Comment is posted listing remaining blockers
+- [ ] Format: "Blocker #N resolved. Still blocked by: #X, #Y"
+
+### Manual Block Assertions
+
+- [ ] Manual blocks (external, waiting for, approval) are NOT auto-unblocked
+- [ ] Warning is logged for manual blocks
+- [ ] Issue state is preserved for manual review
+
+### Edge Case Assertions
+
+- [ ] No issues blocked: Script completes with info message
+- [ ] Circular dependencies: Detected and reported with resolution suggestions
+- [ ] Graph mode: ASCII output to terminal, Mermaid when piped
+
+## Scenarios
+
+### Scenario 1: Single Blocker - Full Unblock
+
+Given issue #A is open with label "blocked"
+And issue #A body contains "Blocked by: #100"
+And issue #100 is the only blocker
+When issue #100 is closed
+Then workflow triggers with event action "closed"
+And script finds #A blocked by #100
+And script removes "blocked" label from #A
+And script posts comment "Auto-unblocked: #100 completed [timestamp]"
+
+**Verification:**
+
+```bash
+# Before: Create blocked issue
+gh issue create --title "Dependent task" --body "Blocked by: #100" --label "blocked"
+
+# After: Close blocker and verify
+gh issue close 100
+# Wait for workflow
+gh issue view A --json labels,comments \
+  --jq '{labels: .labels[].name, comment: .comments[-1].body}'
+# Expected: No "blocked" label, comment with "Auto-unblocked"
+```
+
+### Scenario 2: Multiple Blockers - Partial Unblock
+
+Given issue #B is open with label "blocked"
+And issue #B body contains "Blocked by: #100, #101, #102"
+And issue #100 is one of three blockers
+When issue #100 is closed
+Then workflow triggers
+And script finds #B blocked by #100
+And script detects other blockers (#101, #102)
+And script keeps "blocked" label on #B
+And script posts "Blocker #100 resolved. Still blocked by: #101, #102"
+
+**Verification:**
+
+```bash
+# Check issue still has blocked label and updated comment
+gh issue view B --json labels,comments \
+  --jq '{labels: .labels[].name, lastComment: .comments[-1].body}'
+# Expected: "blocked" label present, comment shows remaining blockers
+```
+
+### Scenario 3: No Dependent Issues
+
+Given issue #100 is closed
+And no other issues contain "Blocked by: #100"
+When workflow triggers
+Then script searches for blocked issues
+And script finds no matches
+And script logs "No issues blocked by #100"
+And no comments are posted
+
+### Scenario 4: Manual Block - Skip Auto-Unblock
+
+Given issue #C is open with label "blocked"
+And issue #C body contains "Blocked by: #100 (waiting for external approval)"
+When issue #100 is closed
+Then workflow triggers
+And script detects manual blocker keyword "waiting for"
+And script logs warning "has manual blocker - skipping auto-unblock"
+And "blocked" label remains on #C
+And no comment is posted
+
+**Manual block keywords:**
+
+- "waiting for"
+- "external"
+- "approval"
+- "client"
+- "vendor"
+- "third party"
+
+### Scenario 5: Circular Dependency Detection
+
+Given issue #A body contains "Blocked by: #B"
+And issue #B body contains "Blocked by: #C"
+And issue #C body contains "Blocked by: #A"
+When script runs with --graph flag
+Then circular dependency is detected
+And warning is logged with cycle path: "#A #B #C #A"
+And resolution suggestions are provided
+And rework cost is estimated (LOW/MEDIUM/HIGH)
+
+### Scenario 6: Issue Without Blocked Label - Ignored
+
+Given issue #D body contains "Blocked by: #100" in text
+And issue #D does NOT have "blocked" label
+When issue #100 is closed
+Then workflow triggers
+And script searches for blocked issues
+And script verifies each candidate has "blocked" label
+And script skips #D (no blocked label)
+
+### Scenario 7: Dry Run Mode
+
+Given script is run without --apply flag
+When processing blocked issues
+Then script outputs "[DRY-RUN] Would remove 'blocked' label"
+And script outputs "[DRY-RUN] Would add comment"
+And no actual changes are made
+And final message says "Use --apply to make changes"
+
+### Scenario 8: Graph Output - Terminal
+
+Given script is run with --graph flag
+And output is to terminal (TTY)
+When processing issue #100
+Then ASCII dependency graph is displayed
+And graph shows closed issue as root
+And graph shows dependent issues with status
+And connectors use Unicode box-drawing characters
+
+### Scenario 9: Graph Output - Piped
+
+Given script is run with --graph flag
+And output is piped (not TTY)
+When processing issue #100
+Then Mermaid graph syntax is output
+And format is "graph TD" with node definitions
+And edges show blocker relationships
+
+## Edge Cases
+
+### Edge Case 1: Recently Closed Issues Auto-Detection
+
+Given no issue number is provided to script
+When script runs without arguments
+Then script auto-detects issues closed within last hour
+And processes all detected issues
+And logs count of issues found
+
+### Edge Case 2: Comment Pattern Variations
+
+Given issues use different "Blocked by" formats
+When script parses blocking info
+Then "Blocked by: #100" is matched
+And "Blocked by #100" (no colon) is matched
+And "blocked by #100" (lowercase) is matched
+And "Blocked by #100, #101" (comma list) is matched
+
+### Edge Case 3: API Rate Limiting
+
+Given GitHub API rate limits are approached
+When script makes API calls
+Then errors are handled gracefully
+And script continues with available data
+And warning is logged if calls fail
+
+### Edge Case 4: Invalid Issue References
+
+Given "Blocked by #99999" references non-existent issue
+When script processes blockers
+Then script handles missing issue gracefully
+And does not fail with API error
+
+## Test Evidence Format
+
+For each test scenario, record:
+
+```markdown
+### Test: [Scenario Name]
+
+**Date:** YYYY-MM-DD
+**Blocker Issue:** #N (closed issue)
+**Dependent Issue:** #M (blocked issue)
+**Expected:** [expected outcome]
+**Actual:** [actual outcome]
+**Workflow Run:** [run ID or link]
+**Status:** PASS/FAIL
+```
+
+## Regression Checklist
+
+Use this checklist when modifying the workflow or script:
+
+- [ ] Workflow triggers only on issues.closed
+- [ ] Script finds blocked issues correctly
+- [ ] Single blocker: label removed, comment posted
+- [ ] Multiple blockers: label kept, comment updated
+- [ ] Manual blocks are not auto-unblocked
+- [ ] Circular dependencies are detected
+- [ ] Graph output works (terminal and piped)
+- [ ] Dry run mode works correctly
+- [ ] No breaking changes to script arguments
+- [ ] Error handling is graceful

--- a/skills/issue-driven-delivery/templates/sync-blocked-status.yml
+++ b/skills/issue-driven-delivery/templates/sync-blocked-status.yml
@@ -1,0 +1,47 @@
+# Blocked Status Sync Workflow Template
+#
+# This workflow automatically unblocks dependent issues when blocking issues are closed.
+# Copy to .github/workflows/sync-blocked-status.yml (or auto-unblock.yml) and customize.
+#
+# Sync Logic:
+#   1. Trigger on issue close
+#   2. Search for issues with "Blocked by #N" in body/comments
+#   3. Verify each candidate has "blocked" label
+#   4. If sole blocker: Remove label, post "Auto-unblocked" comment
+#   5. If multiple blockers: Post update comment, keep label
+#
+# Requirements:
+#   - `scripts/issue-driven-delivery/unblock-dependents.sh` must exist in repo
+#   - Permissions: issues:write for label changes and commenting
+#
+# The script supports:
+#   - Multi-blocker tracking (comma-separated lists)
+#   - Manual block detection (skips external/approval blockers)
+#   - Circular dependency detection with resolution suggestions
+#   - Dependency graph visualization (--graph flag)
+#   - Dry-run mode (default, use --apply for real changes)
+#
+# See: docs/playbooks/blocked-sync.md for usage details.
+
+name: Auto-unblock Dependents
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  unblock:
+    name: Unblock dependent issues
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run unblock script
+        run: |
+          chmod +x ./scripts/issue-driven-delivery/unblock-dependents.sh
+          ./scripts/issue-driven-delivery/unblock-dependents.sh ${{ github.event.issue.number }} --apply
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add template workflow `sync-blocked-status.yml` based on existing `auto-unblock.yml`
- Add comprehensive BDD test file with 9 scenarios and edge cases
- Add playbook `blocked-sync.md` with Mermaid diagram and troubleshooting guide
- Update playbooks README index

## Context

The core functionality for blocked/blocking sync already exists:
- `.github/workflows/auto-unblock.yml` - Installed workflow
- `scripts/issue-driven-delivery/unblock-dependents.sh` - Full implementation

This PR completes #146 by adding the template version for reusability and comprehensive documentation.

## Test Plan

- [ ] Review BDD test scenarios cover all workflow behavior
- [ ] Verify template workflow matches installed workflow
- [ ] Verify playbook documentation is complete
- [ ] Verify linting passes (`npm run lint`)

Refs: #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)