### PR TITLE
fix(persona-switching): update platform docs to include WSL2 and Git Bash

### DIFF
--- a/skills/persona-switching/references/persona-config-template.sh
+++ b/skills/persona-switching/references/persona-config-template.sh
@@ -5,8 +5,8 @@
 # IMPORTANT: Set file permissions to 600 (chmod 600 <this-file>)
 # This file contains account mappings but no secrets.
 #
-# Platform: Linux/macOS only (requires bash 4.0+, gpg, gh CLI)
-# Windows users: Use WSL2 or Git Bash with GPG4Win
+# Platform: Linux, macOS, WSL2, Git Bash (requires bash 4.0+, gpg, gh CLI)
+# Windows users: Requires WSL2 or Git Bash with GPG4Win
 #
 # Usage:
 #   source ~/.config/{{REPO_NAME}}/persona-config.sh


### PR DESCRIPTION
## Summary

- Updated persona-config-template.sh platform documentation to correctly include WSL2 and Git Bash as supported environments
- The script already worked in these environments; documentation was misleading

## Test plan

- [x] Script syntax validated with `bash -n`
- [x] Verified script loads successfully in bash environment on Windows

Refs: #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)