### PR TITLE
docs(process): add Bug Fix TDD Workflow to AGENTS.md (#157)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,17 @@ These rules tighten the workflow for autonomous execution.
   - See [BDD Checklist Templates](docs/references/bdd-checklist-templates.md) for
     concrete vs process-only verification patterns. TDD applies equally to documentation
     as it does to code - no "verify after" changes allowed.
+  - **Bug Fix TDD Workflow:** When a bug is discovered during implementation, follow this
+    strict sequence:
+    1. **STOP** - Do not fix immediately, even if the fix seems obvious
+    2. **Write failing test** - Create a test that reproduces the bug
+    3. **Verify test fails** - Confirm the test fails with the current code
+    4. **Commit failing test** - Record the RED phase with evidence
+    5. **Implement fix** - Make the minimum change to fix the bug
+    6. **Verify test passes** - Confirm the fix resolves the issue
+    7. **Commit fix** - Record the GREEN phase with evidence
+       This applies even when the fix is trivial - the test documents the bug and prevents
+       regression.
 - **Fallback stays compliant.** If handing off to a human, the same skills-first
   workflow still applies.
 - **PR close policy.** Follow the README merge policy (rebase, then choose


### PR DESCRIPTION
## Summary
- Adds explicit Bug Fix TDD Workflow guidance to AGENTS.md
- Documents the correct sequence when bugs are discovered mid-implementation
- Ensures test-first discipline even for seemingly obvious fixes

## Changes
Added a new sub-section under TDD enforcement with a 7-step workflow:
1. STOP - Don't fix immediately
2. Write failing test
3. Verify test fails
4. Commit failing test (RED)
5. Implement fix
6. Verify test passes
7. Commit fix (GREEN)

## Test plan
- [x] Lint passes (`npm run lint`)
- [x] BDD checklist criteria met
- [x] Change integrates cleanly with existing TDD enforcement section

## Evidence
- Commit: 7411c0e

Refs: #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)