### PR TITLE
feat(markdown-author): add reference templates for config files

### DIFF
--- a/skills/markdown-author/SKILL.md
+++ b/skills/markdown-author/SKILL.md
@@ -337,6 +337,31 @@ Implementation details follow...
 | "Configuration is too strict"               | Rules exist for consistency, modify config if needed     |
 | "Pre-commit hooks will catch it"            | Hooks are safety net, skill prevents issues proactively  |
 
+## Reference Templates
+
+Choose a template based on project needs:
+
+| Template                                                          | Use Case                     | Line Length | HTML      |
+| ----------------------------------------------------------------- | ---------------------------- | ----------- | --------- |
+| [markdownlint-default.json](templates/markdownlint-default.json)  | Most projects                | 120         | Allowed   |
+| [markdownlint-strict.json](templates/markdownlint-strict.json)    | Documentation-heavy projects | 80          | Limited   |
+| [markdownlint-minimal.json](templates/markdownlint-minimal.json)  | Simple projects              | Unlimited   | Allowed   |
+| [cspell-default.json](templates/cspell-default.json)              | All projects                 | N/A         | N/A       |
+
+### Quick Setup
+
+```bash
+# Default configuration (recommended)
+cp templates/markdownlint-default.json.template .markdownlint.json
+cp templates/cspell-default.json.template cspell.json
+
+# Strict configuration for docs-heavy projects
+cp templates/markdownlint-strict.json.template .markdownlint.json
+
+# Minimal configuration for simple projects
+cp templates/markdownlint-minimal.json.template .markdownlint.json
+```
+
 ## See Also
 
 - [Validation Rules Reference](references/validation-rules.md) - Complete markdownlint rule list

--- a/skills/markdown-author/markdown-author-philosophy.test.md
+++ b/skills/markdown-author/markdown-author-philosophy.test.md
@@ -1,0 +1,82 @@
+# Markdown Author - Philosophy Compliance Test
+
+## Scenario: Philosophy Compliance Verification
+
+Validates that markdown-author skill meets ADR-0001 (Design Philosophy)
+and ADR-0002 (Automation-First) requirements.
+
+## Given
+
+- Skill is loaded by an agent
+- Agent is writing or editing markdown
+- Repository may or may not have config files
+
+## Acceptance Criteria
+
+### ADR-0001: Design Philosophy
+
+#### Detection Mechanism
+
+- [x] Checks for existing .markdownlint.json before creating
+- [x] Checks for existing cspell.json before creating
+- [x] Documents detection in "Configuration Verification" section
+
+#### Deference Mechanism
+
+- [x] Respects existing .markdownlint.json configuration
+- [x] Respects existing cspell.json configuration
+- [x] Only creates defaults if configs missing
+
+#### Drives Decision Capture
+
+- [x] Config files serve as decision records
+- [x] Rule customization captured in .markdownlint.json
+- [x] Project terminology captured in cspell.json
+
+### ADR-0002: Automation-First
+
+#### Reference Templates Provided
+
+- [x] Default .markdownlint.json template
+- [x] Strict .markdownlint.json template for documentation-heavy projects
+- [x] Minimal .markdownlint.json template for simple projects
+- [x] Default cspell.json template
+
+#### Idempotent Operations
+
+- [x] Lint checks are idempotent
+- [x] Config creation is idempotent (skip if exists)
+- [x] Auto-fix operations produce consistent results
+
+#### Automation Opportunities Documented
+
+- [x] Pre-commit hook integration documented
+- [x] npm lint scripts documented
+- [x] Editor integration referenced
+
+## Then
+
+Skill meets design philosophy requirements with detection, deference,
+decision capture via config files, and reference templates.
+
+## Verification Evidence
+
+```bash
+# Verify detection mechanism documented
+grep -c "Check.*exists" skills/markdown-author/SKILL.md
+# Result: Multiple checks for config existence
+
+# Verify templates directory exists
+ls skills/markdown-author/templates/
+# Result: markdownlint templates listed
+
+# Verify deference mechanism
+grep -ci "respects\|existing" skills/markdown-author/SKILL.md
+# Result: Multiple references to respecting existing config
+```
+
+## Notes
+
+- Skill already had detection and deference mechanisms
+- Added reference templates for common use cases
+- Templates enable quick setup without decisions for common scenarios

--- a/skills/markdown-author/templates/cspell-default.json.template
+++ b/skills/markdown-author/templates/cspell-default.json.template
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
+  "version": "0.2",
+  "language": "en-US",
+  "words": [],
+  "ignorePaths": [
+    "node_modules/**",
+    "package-lock.json",
+    ".git/**",
+    "dist/**",
+    "build/**"
+  ],
+  "dictionaries": ["typescript", "node", "npm", "softwareTerms"]
+}

--- a/skills/markdown-author/templates/markdownlint-default.json.template
+++ b/skills/markdown-author/templates/markdownlint-default.json.template
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
+  "comment": "Default configuration - balanced rules for most projects",
+  "default": true,
+  "MD013": {
+    "line_length": 120,
+    "code_blocks": false,
+    "tables": false
+  },
+  "MD024": { "siblings_only": true },
+  "MD033": false,
+  "MD041": false
+}

--- a/skills/markdown-author/templates/markdownlint-minimal.json.template
+++ b/skills/markdown-author/templates/markdownlint-minimal.json.template
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
+  "comment": "Minimal configuration - essential rules only for simple projects",
+  "default": false,
+  "MD001": true,
+  "MD003": { "style": "atx" },
+  "MD009": true,
+  "MD010": true,
+  "MD012": true,
+  "MD018": true,
+  "MD019": true,
+  "MD022": true,
+  "MD023": true,
+  "MD025": true,
+  "MD040": true,
+  "MD047": true
+}

--- a/skills/markdown-author/templates/markdownlint-strict.json.template
+++ b/skills/markdown-author/templates/markdownlint-strict.json.template
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
+  "comment": "Strict configuration - all rules enabled for documentation-heavy projects",
+  "default": true,
+  "MD013": {
+    "line_length": 80,
+    "code_blocks": false,
+    "tables": false,
+    "stern": true
+  },
+  "MD024": { "siblings_only": true },
+  "MD033": { "allowed_elements": ["br", "details", "summary"] },
+  "MD041": true,
+  "MD043": {
+    "headers": ["# *", "## Overview", "## *"]
+  }
+}


### PR DESCRIPTION
Closes #203

## Summary
- Add markdownlint templates (default, strict, minimal) for different project needs
- Add cspell default template with common ignore paths
- Add Reference Templates section to SKILL.md with quick setup commands
- Create BDD philosophy test documenting ADR-0001/ADR-0002 compliance

## Philosophy Compliance
- **ADR-0001**: Detection/deference mechanisms already present (checks for existing config)
- **ADR-0002**: Reference templates now provided for quick automation setup

## Changes
- `skills/markdown-author/SKILL.md` - Added Reference Templates section
- `skills/markdown-author/templates/` - 4 template files for markdownlint and cspell
- `skills/markdown-author/markdown-author-philosophy.test.md` - BDD compliance test