### PR TITLE
feat(skill): integrate persona-switching with repo-best-practices-bootstrap

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -173,6 +173,7 @@
     "usermod",
     "USERPROFILE",
     "venv",
+    "VERSINFO",
     "vimrc",
     "warnaserror",
     "WCAG",

--- a/skills/repo-best-practices-bootstrap/SKILL.md
+++ b/skills/repo-best-practices-bootstrap/SKILL.md
@@ -25,6 +25,7 @@ Applicable to both greenfield (new repository) and brownfield (existing reposito
 6. Development Standards - .editorconfig, .gitignore, .gitattributes, pre-commit config
 7. Project Management - Project board linking, kanban/sprint workflow configuration
 8. Standard Tooling - husky, prettier, markdownlint, lint-staged, local secret scanning
+9. Multi-Identity Workflow (Optional) - Persona-switching for role-based commits and GPG signing
 
 ## When to Use
 
@@ -293,6 +294,61 @@ gh api repos/OWNER/REPO/branches/main/protection/required_signatures -X POST
 Generate `docs/playbooks/enable-signed-commits.md` from template for future reference.
 
 See [Signed Commits Playbook Template](templates/playbooks/enable-signed-commits.md).
+
+### Step 4a: Persona-Switching Integration (Optional)
+
+After core configuration, offer multi-identity workflow setup:
+
+#### Detection
+
+Check if persona-switching is already configured:
+
+```bash
+# Check for existing playbook
+if [ -f "docs/playbooks/persona-switching.md" ]; then
+  echo "Persona-switching already configured - skipping"
+  # Report as "already configured" in summary
+else
+  # Proceed to prompt
+fi
+```
+
+#### Prompt
+
+Ask user: **"Enable multi-identity workflow?"** (Y/n)
+
+- **Default:** No (persona-switching is optional)
+- **If Yes:** Chain to persona-switching skill setup flow
+- **If No:** Record opt-out and continue
+
+#### If Enabled
+
+Chain to `persona-switching` skill setup flow:
+
+1. **Role Discovery** - Parse existing `docs/roles/*.md` or use defaults
+2. **Security Profile Configuration** - Map personas to GitHub accounts
+3. **Generate Artifacts:**
+   - `docs/playbooks/persona-switching.md` - Repository playbook
+   - `~/.config/<repo-name>/persona-config.sh` - User's shell config
+4. **Verify Setup** - Test `use_persona` and `show_persona` commands
+
+See [persona-switching skill](../persona-switching/SKILL.md) for full setup flow.
+
+#### If Declined
+
+Record opt-out in `.repo-bootstrap.yml`:
+
+```yaml
+opt_out:
+  features:
+    - persona-switching # optional - user declined
+```
+
+No justification required (optional feature).
+
+#### Continue Bootstrap
+
+After persona-switching setup completes (or is declined), continue with Step 5.
 
 ### Step 5: Generate CI/CD Workflow
 

--- a/skills/repo-best-practices-bootstrap/references/checklist.md
+++ b/skills/repo-best-practices-bootstrap/references/checklist.md
@@ -1,7 +1,8 @@
 # Repository Best Practices Checklist
 
-This checklist covers 6 categories of repository best practices. Each item includes
-platform-specific CLI commands for GitHub (primary), Azure DevOps, and GitLab.
+This checklist covers 8 mandatory categories plus 1 optional category of repository
+best practices. Each item includes platform-specific CLI commands for GitHub
+(primary), Azure DevOps, and GitLab.
 
 **Legend:**
 
@@ -1292,3 +1293,66 @@ pre-commit install
 # Run on all files
 pre-commit run --all-files
 ```
+
+## 9. Multi-Identity Workflow (Optional)
+
+### 9.1 Persona-Switching
+
+**Description:** Enable multi-identity Git/GitHub workflows with role-specific personas.
+
+**Cost:** Free
+
+**Opt-out:** `multi-identity` (category) or `persona-switching` (feature)
+
+**Detection:**
+
+```bash
+# Check if already configured
+test -f docs/playbooks/persona-switching.md && echo "CONFIGURED" || echo "NOT CONFIGURED"
+```
+
+**Prerequisites:**
+
+```bash
+# Check required tools
+command -v bash &>/dev/null && echo "bash: OK" || echo "bash: MISSING"
+command -v gpg &>/dev/null && echo "gpg: OK" || echo "gpg: MISSING"
+command -v gh &>/dev/null && echo "gh: OK" || echo "gh: MISSING"
+
+# Check bash version (requires 4.0+)
+if [ "${BASH_VERSINFO[0]}" -ge 4 ]; then
+  echo "bash version: OK (${BASH_VERSION})"
+else
+  echo "bash version: NEEDS UPGRADE (${BASH_VERSION})"
+fi
+```
+
+**Prompt:**
+
+Ask user: **"Enable multi-identity workflow?"** (Y/n)
+
+- Default: No (optional feature)
+- If Yes: Chain to persona-switching skill setup flow
+- If No: Record opt-out and continue
+
+**Setup (if enabled):**
+
+The persona-switching skill handles the full setup flow:
+
+1. Role Discovery - Parse existing `docs/roles/*.md` or use defaults
+2. Security Profile Configuration - Map personas to GitHub accounts
+3. Generate Artifacts:
+   - `docs/playbooks/persona-switching.md` - Repository playbook
+   - `~/.config/<repo-name>/persona-config.sh` - User's shell config
+4. Verify Setup - Test commands
+
+**Opt-out Recording:**
+
+```yaml
+# .repo-bootstrap.yml
+opt_out:
+  features:
+    - persona-switching # optional - user declined
+```
+
+See [persona-switching skill](../../persona-switching/SKILL.md) for full setup flow.

--- a/skills/repo-best-practices-bootstrap/repo-best-practices-bootstrap.test.md
+++ b/skills/repo-best-practices-bootstrap/repo-best-practices-bootstrap.test.md
@@ -188,3 +188,53 @@
 - [ ] Azure DevOps commands documented (CLI limitations noted)
 - [ ] GitLab commands documented (API requirements noted)
 - [ ] Bitbucket documented as manual-only
+
+## Persona-Switching Integration
+
+### Scenario: User enables persona-switching during bootstrap
+
+**Context:** User runs bootstrap on a new repository and chooses to enable
+multi-identity workflow.
+
+**Expected behaviour:**
+
+- [ ] Skill prompts "Enable multi-identity workflow?" during bootstrap
+- [ ] Prompt defaults to No (persona-switching is optional)
+- [ ] If user selects Yes, skill chains to persona-switching setup flow
+- [ ] Persona-switching skill generates playbook in `docs/playbooks/persona-switching.md`
+- [ ] Persona-switching skill generates shell config in `~/.config/<repo-name>/persona-config.sh`
+- [ ] Bootstrap continues with remaining items after persona-switching setup completes
+- [ ] Opt-out decision recorded in `.repo-bootstrap.yml` if user declines
+
+### Scenario: User declines persona-switching during bootstrap
+
+**Context:** User runs bootstrap and chooses not to enable multi-identity workflow.
+
+**Expected behaviour:**
+
+- [ ] Skill accepts No answer without requiring justification (optional feature)
+- [ ] Skill records opt-out in `.repo-bootstrap.yml` with reason "optional - user declined"
+- [ ] Skill continues with remaining bootstrap items
+- [ ] No persona-switching playbook or shell config created
+
+### Scenario: Bootstrap re-run with existing persona-switching
+
+**Context:** User re-runs bootstrap on repository that already has persona-switching configured.
+
+**Expected behaviour:**
+
+- [ ] Skill detects existing `docs/playbooks/persona-switching.md`
+- [ ] Skill skips persona-switching prompt (already configured)
+- [ ] Skill reports persona-switching as "already configured" in summary
+- [ ] No duplicate artifacts created
+
+### Scenario: Persona-switching prerequisite check
+
+**Context:** User enables persona-switching but lacks bash/GPG/gh prerequisites.
+
+**Expected behaviour:**
+
+- [ ] Persona-switching skill checks prerequisites before setup
+- [ ] Missing prerequisites reported with installation instructions
+- [ ] User can choose to continue without persona-switching
+- [ ] Bootstrap continues with remaining items if user declines


### PR DESCRIPTION
## Summary

- Adds multi-identity workflow as optional Step 4a during bootstrap
- Detection of existing persona-switching configuration
- Prompt for enablement (defaults to No - optional feature)
- Chain to persona-switching skill setup flow if enabled
- Opt-out recording without justification required

## Changes

- **SKILL.md**: Added Step 4a with detection logic, prompt text, and setup flow documentation
- **checklist.md**: Added Category 9 (Multi-Identity Workflow) with persona-switching checklist item
- **BDD tests**: Added 4 scenarios covering enable/decline/re-run/prerequisite-check paths
- **cspell.json**: Added VERSINFO

## Test plan

- [ ] Review BDD test scenarios cover all acceptance criteria from #156
- [ ] Verify checklist detection commands work
- [ ] Verify skill cross-references are valid

Refs: #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)