### PR TITLE
feat(process): add estimation/sizing guidance to issue-driven-delivery

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -175,6 +175,7 @@
     "venv",
     "VERSINFO",
     "vimrc",
+    "VSTS",
     "warnaserror",
     "WCAG",
     "webapi",

--- a/skills/issue-driven-delivery/SKILL.md
+++ b/skills/issue-driven-delivery/SKILL.md
@@ -142,6 +142,127 @@ See [Component Tagging](references/component-tagging.md) for complete tagging
 taxonomy (priority levels, work types, blocked workflow), platform-specific CLI
 commands, enforcement rules, and auto-assignment strategy.
 
+## Work Item Estimation (Optional)
+
+Estimation helps with sprint planning, velocity tracking, and identifying work that
+should be decomposed. Sizing is optional - teams choose whether and how to estimate.
+
+### Sizing Approaches
+
+Choose one approach and use it consistently:
+
+| Approach       | Scale                         | When to Use                          |
+| -------------- | ----------------------------- | ------------------------------------ |
+| Story Points   | 1, 2, 3, 5, 8, 13 (Fibonacci) | Teams familiar with agile estimation |
+| T-Shirt Sizing | XS, S, M, L, XL               | Quick relative sizing, new teams     |
+| Time-Based     | Hours or Days                 | Fixed-scope work, client billing     |
+
+**Guidance:** Start with T-shirt sizing if new to estimation. Story points are more
+precise but require team calibration. Time-based estimates are useful for external
+commitments but can create pressure.
+
+### When to Size
+
+- **During refinement:** Size work items before transitioning to implementation (step 7)
+- **Before sprint planning (Scrum):** Sized items enable capacity planning
+- **Optional DoR item:** Teams can add sizing to their Definition of Ready
+
+### Recording Estimates
+
+**GitHub Projects:**
+
+```bash
+# Set Size field in project (requires project field configured)
+gh project item-edit --project-id PROJECT_ID --id ITEM_ID \
+  --field-id FIELD_ID --single-select-option-id OPTION_ID
+
+# Or add size label
+gh issue edit N --add-label "size:M"
+```
+
+**Azure DevOps:**
+
+```bash
+# Set Story Points field
+az boards work-item update --id N \
+  --fields "Microsoft.VSTS.Scheduling.StoryPoints=5"
+
+# Or set Effort field
+az boards work-item update --id N \
+  --fields "Microsoft.VSTS.Scheduling.Effort=8"
+```
+
+**Jira:**
+
+```bash
+# Set Story Points (requires jira CLI)
+jira issue edit ISSUE-123 --custom "Story Points=5"
+
+# Or set Time Estimate
+jira issue edit ISSUE-123 --time-estimate "2d"
+```
+
+**Fallback:** Add estimate in issue body:
+
+```markdown
+## Estimate
+
+Size: M (3 story points)
+```
+
+### Decomposition Thresholds
+
+Large items should be decomposed into smaller work items. Thresholds are guidance,
+not hard rules - use judgement based on team context.
+
+| Approach     | Threshold    | Recommendation                              |
+| ------------ | ------------ | ------------------------------------------- |
+| Story Points | >5 points    | Consider decomposition into smaller stories |
+| T-Shirt      | XL or larger | Should be decomposed into M or smaller      |
+| Time-Based   | >2 days      | Consider breaking into smaller tasks        |
+
+**When threshold exceeded:**
+
+1. Review if work can be split into independent deliverables
+2. Use `requirements-gathering` skill decomposition workflow
+3. Create child issues for each deliverable
+4. Re-estimate children (sum should approximate original)
+
+See [requirements-gathering skill](../requirements-gathering/SKILL.md) for
+decomposition guidance.
+
+### Team Sizing Preferences
+
+Document your team's sizing decisions in ways-of-working:
+
+```markdown
+# docs/ways-of-working/estimation.md
+
+## Estimation Approach
+
+Our team uses **T-shirt sizing** (XS, S, M, L, XL).
+
+### Calibration Reference
+
+| Size | Typical Scope                    | Example                     |
+| ---- | -------------------------------- | --------------------------- |
+| XS   | Config change, typo fix          | Update environment variable |
+| S    | Single function/component change | Add validation to endpoint  |
+| M    | Feature with tests               | New API endpoint            |
+| L    | Cross-cutting change             | Refactor authentication     |
+| XL   | Should be decomposed             | N/A - too large             |
+
+### Decomposition Threshold
+
+Items sized **L or larger** should be reviewed for decomposition.
+
+### Sizing Ceremony
+
+We size during **sprint planning** after grooming.
+```
+
+Reference your team's estimation approach in AGENTS.md or repository documentation.
+
 ## Work Item Prioritization
 
 When selecting which work item to action next, apply these prioritization rules in order:

--- a/skills/issue-driven-delivery/issue-driven-delivery-estimation.test.md
+++ b/skills/issue-driven-delivery/issue-driven-delivery-estimation.test.md
@@ -1,0 +1,122 @@
+# Issue-Driven Delivery - Estimation/Sizing Tests
+
+## RED: Failure scenarios (expected without feature)
+
+### Scenario A: Large work item not identified before sprint
+
+**Context:** Team commits to a work item without sizing; it takes 3x expected effort.
+
+**Baseline failure to record:**
+
+- No sizing guidance in skill
+- Large items not identified during refinement
+- Sprint commitment unreliable
+- No decomposition trigger
+
+**Observed baseline (RED):**
+
+- Sprint goals missed due to underestimated work
+- No mechanism to flag oversized items
+- Team velocity unpredictable
+
+### Scenario B: Inconsistent sizing across team
+
+**Context:** Different team members use different estimation approaches.
+
+**Baseline failure to record:**
+
+- No standard sizing approaches documented
+- No guidance on where to record estimates
+- No team agreement on sizing method
+
+**Observed baseline (RED):**
+
+- Velocity tracking unreliable (mixing approaches)
+- Sprint planning lacks consistency
+- New team members lack onboarding for sizing
+
+## GREEN: Expected behaviour with feature
+
+### Sizing Approaches Documentation
+
+- [ ] Story points documented (Fibonacci: 1, 2, 3, 5, 8, 13)
+- [ ] T-shirt sizing documented (XS, S, M, L, XL)
+- [ ] Time-based estimates documented (hours/days)
+- [ ] Guidance: sizing is optional (team choice)
+- [ ] Guidance: pick one approach, use consistently
+
+### When to Size
+
+- [ ] Sizing occurs during refinement phase (before step 7)
+- [ ] Sizing is optional but recommended for sprint planning
+- [ ] DoR can include sizing as optional item
+- [ ] Sizing recorded before implementation begins
+
+### Recording Estimates
+
+- [ ] GitHub: Use project field (Size or Estimate column)
+- [ ] Azure DevOps: Use Story Points or Effort field
+- [ ] Jira: Use Story Points or Time Estimate field
+- [ ] Fallback: Add estimate in issue body or comment
+
+### Decomposition Thresholds
+
+- [ ] Story points: >5 points triggers decomposition recommendation
+- [ ] T-shirt sizing: XL or larger triggers decomposition
+- [ ] Time-based: >2 days triggers decomposition
+- [ ] Threshold is guidance, not hard rule
+- [ ] Cross-reference to requirements-gathering for decomposition workflow
+
+### Ways-of-Working Template
+
+- [ ] Template includes sizing preferences section
+- [ ] Documents team's chosen approach
+- [ ] Documents team's decomposition threshold
+- [ ] Documents sizing ceremony timing (planning, refinement)
+
+### Platform-Specific Commands
+
+- [ ] GitHub: Project field commands documented
+- [ ] Azure DevOps: Work item field commands documented
+- [ ] Jira: Issue field commands documented
+
+## Error Handling Scenarios
+
+### Scenario: Team has no sizing preference
+
+**Expected behaviour:**
+
+- [ ] Skill notes sizing is optional
+- [ ] Suggests trying approaches to find fit
+- [ ] Provides comparison of approaches
+- [ ] Does not block workflow without sizing
+
+### Scenario: Item exceeds decomposition threshold
+
+**Expected behaviour:**
+
+- [ ] Warning displayed during refinement
+- [ ] Link to requirements-gathering decomposition section
+- [ ] User can proceed (threshold is guidance)
+- [ ] Decomposition recommendation logged
+
+## Verification Checklist
+
+### Documentation
+
+- [ ] Sizing approaches section in SKILL.md
+- [ ] Decomposition thresholds documented
+- [ ] Cross-reference to requirements-gathering exists
+- [ ] Ways-of-working template updated
+
+### Platform Coverage
+
+- [ ] GitHub project fields documented
+- [ ] Azure DevOps fields documented
+- [ ] Jira fields documented
+
+### Integration
+
+- [ ] DoR can include sizing (optional item)
+- [ ] Refinement phase mentions sizing timing
+- [ ] Sprint planning references sizing data


### PR DESCRIPTION
## Summary

- Adds optional work item estimation guidance to support sprint planning
- Three sizing approaches: story points, T-shirt, time-based
- Platform-specific commands for GitHub, Azure DevOps, and Jira
- Decomposition thresholds with cross-reference to requirements-gathering
- Ways-of-working template for team sizing preferences

## Changes

- **SKILL.md**: Added Work Item Estimation section with sizing approaches, recording commands, decomposition thresholds, and team preferences template
- **BDD test file**: Added scenarios for sizing approaches, threshold handling, team preferences
- **cspell.json**: Added VSTS

## Test plan

- [ ] Review BDD test scenarios cover all acceptance criteria from #114
- [ ] Verify platform-specific commands are accurate
- [ ] Verify cross-reference to requirements-gathering is valid

Refs: #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)