### PR TITLE
fix(ci): require substantive code review comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,3 +32,17 @@ Example:
 Exemplar PR with proper evidence: #263
 See CONTRIBUTING.md for complete checklist requirements
 -->
+
+## For Reviewers
+
+<!--
+When approving, include substantive feedback (>50 chars) such as:
+- Files reviewed and verified
+- Potential issues checked (edge cases, security, performance)
+- Specific positive or constructive feedback
+
+Example approval comment:
+"Reviewed dangerfile.js and CONTRIBUTING.md. Logic for review depth check
+looks correct. Verified MIN_REVIEW_BODY_LENGTH constant is reasonable.
+No security concerns with the new regex patterns."
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,37 @@ merge if not satisfied.
 - PR template: `.github/PULL_REQUEST_TEMPLATE.md`
 - Exemplar PR with proper evidence: [#263](https://github.com/mcj-coder/development-skills/pull/263)
 
+### Code Review Guidelines
+
+**Substantive reviews required.** Empty "LGTM" approvals are flagged by DangerJS. Reviews must
+include meaningful feedback (minimum 50 characters).
+
+**What to include in review comments:**
+
+- Files reviewed and verified
+- Potential issues checked (edge cases, security, performance)
+- Specific observations (positive or constructive)
+- Questions or concerns that were resolved
+
+**Exemplar review format:**
+
+```text
+Reviewed [files]. Verified:
+- [Specific check 1]
+- [Specific check 2]
+
+[Any observations or minor suggestions]
+
+Approved - no blocking issues found.
+```
+
+**Exemplar review:**
+
+> Reviewed dangerfile.js and CONTRIBUTING.md. Verified the review depth check
+> logic is correct and MIN_REVIEW_BODY_LENGTH of 50 chars is reasonable.
+> Checked regex patterns for potential edge cases - none found.
+> Documentation clearly explains the new requirement. Approved.
+
 ### Quality Gates
 
 Before submitting PR:

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -196,6 +196,24 @@ async function validate() {
     warn("PR should include a '## Test plan' section.");
   }
 
+  // Rule 8: Review depth - warn on brief/empty approvals
+  const reviews = danger.github.reviews || [];
+  const approvedReviews = reviews.filter((r) => r.state === "APPROVED");
+  const MIN_REVIEW_BODY_LENGTH = 50;
+
+  if (approvedReviews.length > 0) {
+    const briefApprovals = approvedReviews.filter(
+      (r) => !r.body || r.body.trim().length < MIN_REVIEW_BODY_LENGTH,
+    );
+
+    if (briefApprovals.length === approvedReviews.length) {
+      warn(
+        `[Review] All ${approvedReviews.length} approval(s) have brief or empty review bodies. ` +
+          `Substantive reviews should include: files reviewed, potential issues checked, or specific feedback.`,
+      );
+    }
+  }
+
   // Success message if all critical checks pass
   const failures = danger.fails || [];
   if (failures.length === 0) {


### PR DESCRIPTION
## Summary

- Add DangerJS Rule 8 to warn on brief/empty approval reviews (<50 chars)
- Add "For Reviewers" section to PR template with review guidance
- Add "Code Review Guidelines" section to CONTRIBUTING.md with exemplar format

Closes #291

## Test plan

- [x] DangerJS warns on brief approvals ([dangerfile.js:L199-L215](https://github.com/mcj-coder/development-skills/blob/3679f02/dangerfile.js#L199-L215))
- [x] PR template includes reviewer guidance ([PULL_REQUEST_TEMPLATE.md:L36-L48](https://github.com/mcj-coder/development-skills/blob/3679f02/.github/PULL_REQUEST_TEMPLATE.md#L36-L48))
- [x] Exemplar review documented ([CONTRIBUTING.md:L181-L210](https://github.com/mcj-coder/development-skills/blob/3679f02/CONTRIBUTING.md#L181-L210))
- [x] Linting passes ([CI run](https://github.com/mcj-coder/development-skills/actions))

🤖 Generated with [Claude Code](https://claude.ai/code)