### PR TITLE
fix(process): enforce plan approval before implementation

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -1,0 +1,45 @@
+---
+name: General Issue
+about: Report a bug, request a feature, or propose a change
+title: ""
+labels: []
+assignees: ""
+---
+
+## Summary
+
+{Brief description of the issue, feature, or change}
+
+## Plan Approval
+
+<!--
+Before implementation begins, post a plan comment on this issue:
+1. Create plan file at docs/plans/YYYY-MM-DD-issue-N-description.md (if complex)
+2. Post comment with "## Plan" header summarizing implementation approach
+3. Wait for approval comment before starting implementation
+4. See Issue #177 for exemplar
+
+Plan comment template:
+## Plan
+**Approach:** {Brief description}
+**Files to change:** {List}
+**Testing:** {How you'll verify}
+**Awaiting approval to proceed.**
+-->
+
+- [ ] Plan comment posted
+- [ ] Approval received
+
+## Context
+
+{Background information, motivation, or problem statement}
+
+## Acceptance Criteria
+
+- [ ] {Criterion 1}
+- [ ] {Criterion 2}
+- [ ] {Criterion 3}
+
+## Additional Information
+
+{Any other relevant details, links, or screenshots}

--- a/.github/ISSUE_TEMPLATE/skill-spec.md
+++ b/.github/ISSUE_TEMPLATE/skill-spec.md
@@ -12,6 +12,26 @@ assignees: ""
 
 {One sentence: what agents should do when this skill triggers}
 
+## Plan Approval
+
+<!--
+Before implementation begins, post a plan comment on this issue:
+1. Create plan file at docs/plans/YYYY-MM-DD-issue-N-description.md (if complex)
+2. Post comment with "## Plan" header summarizing implementation approach
+3. Wait for approval comment before starting implementation
+4. See Issue #177 for exemplar
+
+Plan comment template:
+## Plan
+**Approach:** {Brief description}
+**Files to change:** {List}
+**Testing:** {How you'll verify}
+**Awaiting approval to proceed.**
+-->
+
+- [ ] Plan comment posted
+- [ ] Approval received
+
 ## Skill Priority
 
 - Priority: P{0-4} ({Safety & Integrity | Quality & Correctness | Consistency & Governance |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,30 @@ agent-facing documentation that helps AI agents apply proven techniques, pattern
    - See [README.md](README.md) for repository standards
    - See [AGENTS.md](AGENTS.md) for agent-specific rules
 
+## Plan Approval Workflow
+
+Before implementation begins on any issue, a plan must be posted and approved:
+
+1. **Post plan comment** on the issue with "## Plan" header summarizing approach
+2. **Wait for approval** - approval comment must contain "Approval acknowledged" or "Plan approved"
+3. **Begin implementation** - only after explicit approval exists
+
+**Enforcement:** DangerJS Rule 9 warns on PRs where the linked issue lacks plan approval.
+
+**Exemplar:** [Issue #177](https://github.com/mcj-coder/development-skills/issues/177) demonstrates
+the complete workflow with proper plan formatting and approval.
+
+**Plan comment format:**
+
+```markdown
+## Plan
+
+**Approach:** {Brief description}
+**Files to change:** {List}
+**Testing:** {How you'll verify}
+**Awaiting approval to proceed.**
+```
+
 ## Creating Skills
 
 ### Process Overview

--- a/skills/issue-driven-delivery/SKILL.md
+++ b/skills/issue-driven-delivery/SKILL.md
@@ -935,6 +935,24 @@ gh issue view N --json comments --jq '.comments[].body' | grep -qiE "approved|lg
 gh issue view N --json body,comments --jq '[.body, .comments[].body] | join(" ")' | grep -qiE "blocked by|depends on|no dependencies|dependencies: none" && echo "PASS: Dependencies documented" || echo "WARN: Dependencies not explicitly documented"
 ```
 
+### Automated Enforcement
+
+Plan approval is enforced automatically via DangerJS (Rule 9). When a PR references an issue:
+
+1. **Plan comment check** - DangerJS verifies the linked issue has a plan comment containing:
+   - "## Plan" or "## Implementation Plan" or "## Refinement" header
+   - Link to `docs/plans/` directory
+   - "Awaiting approval" or "Ready for approval" language
+
+2. **Approval check** - DangerJS verifies an approval comment exists containing:
+   - "Approval acknowledged" or "Plan approved"
+   - "Approved to proceed" or "Proceeding with"
+
+PRs will receive warnings if plan approval is missing. See `dangerfile.js` Rule 9 for implementation.
+
+**Exemplar:** [Issue #177](https://github.com/mcj-coder/development-skills/issues/177) demonstrates
+the complete plan approval workflow with proper comment formatting.
+
 ### DoR Failure Handling
 
 If DoR validation fails, do NOT transition to implementation. Instead:


### PR DESCRIPTION
## Summary

- Add DangerJS Rule 9 to warn when linked issues lack plan comments or approval
- Update issue templates with Plan Approval section
- Create general-issue.md template for non-skill work items
- Update issue-driven-delivery skill with Automated Enforcement section
- Add Plan Approval Workflow section to CONTRIBUTING.md
- Document Issue #177 as workflow exemplar

Closes #292

## Test plan

- [x] DangerJS Rule 9 implemented ([dangerfile.js:L286-L307](https://github.com/mcj-coder/development-skills/blob/fix/292-plan-approval-enforcement/dangerfile.js#L286-L307))
- [x] skill-spec.md template updated ([skill-spec.md:L15-L33](https://github.com/mcj-coder/development-skills/blob/fix/292-plan-approval-enforcement/.github/ISSUE_TEMPLATE/skill-spec.md#L15-L33))
- [x] general-issue.md template created ([general-issue.md](https://github.com/mcj-coder/development-skills/blob/fix/292-plan-approval-enforcement/.github/ISSUE_TEMPLATE/general-issue.md))
- [x] issue-driven-delivery skill updated ([SKILL.md:L938-L954](https://github.com/mcj-coder/development-skills/blob/fix/292-plan-approval-enforcement/skills/issue-driven-delivery/SKILL.md#L938-L954))
- [x] CONTRIBUTING.md updated ([CONTRIBUTING.md:L30-L52](https://github.com/mcj-coder/development-skills/blob/fix/292-plan-approval-enforcement/CONTRIBUTING.md#L30-L52))
- [x] Linting passes ([commit 6a75ade](https://github.com/mcj-coder/development-skills/commit/6a75ade))

---

## For Reviewers

Reviewed files: dangerfile.js, .github/ISSUE_TEMPLATE/skill-spec.md, .github/ISSUE_TEMPLATE/general-issue.md, skills/issue-driven-delivery/SKILL.md, CONTRIBUTING.md

Key verification points:
- DangerJS Rule 9 correctly identifies plan comments using isPlanComment() function
- Approval detection uses isApprovalComment() function with multiple patterns
- Issue templates have consistent Plan Approval section format
- Exemplar reference to Issue #177 is consistent across all updated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)