### PR TITLE
fix(process): add auto-merge config and persona-switching enforcement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,24 @@ Use canonical names from `docs/roles/README.md` when referencing personas.
 3. **Codex available locally** - If installed, use for parallel tasks or local execution
 4. **Load the persona** - Read the relevant `docs/roles/<persona>.md` before executing the delegated task
 
+### PR Review Requirements
+
+Before approving or requesting changes on PRs, you MUST switch personas to ensure separation
+of duties between contributor (implementation) and maintainer (review/merge):
+
+1. **Switch to maintainer persona**: `source ~/.claude/persona-config.sh && use_persona teamlead`
+2. **Verify account**: `gh auth status` (should show `mcj-coder`)
+3. **Then perform review**: `gh pr review <N> --approve --body "..."`
+
+This two-account workflow ensures:
+
+- Contributors cannot approve their own PRs
+- Review accountability is maintained
+- Auto-merge works correctly after approval
+
+**Anti-pattern:** Reviewing as the same account that created the PR will fail with
+"Cannot approve your own pull request".
+
 ### Mandatory Retrospective
 
 After EVERY persona-delegated task completes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,6 +233,30 @@ Approved - no blocking issues found.
 > Checked regex patterns for potential edge cases - none found.
 > Documentation clearly explains the new requirement. Approved.
 
+### Two-Account Workflow
+
+This repository uses a two-account workflow for separation of duties:
+
+| Account         | Role        | Used For                             |
+| --------------- | ----------- | ------------------------------------ |
+| `martincjarvis` | Contributor | Implementation, commits, PR creation |
+| `mcj-coder`     | Maintainer  | Code review, PR approval, merge      |
+
+**Why two accounts?**
+
+- Contributors cannot approve their own PRs (GitHub restriction)
+- Separation ensures review accountability
+- Auto-merge works correctly after maintainer approval
+
+**Switching accounts:**
+
+```bash
+# For agents using persona-config.sh
+source ~/.claude/persona-config.sh
+use_persona teamlead    # Switch to mcj-coder for reviews
+use_persona qa          # Switch to martincjarvis for implementation
+```
+
 ### Quality Gates
 
 Before submitting PR:

--- a/cspell.json
+++ b/cspell.json
@@ -103,6 +103,7 @@
     "lintstagedrc",
     "mapperly",
     "Mapster",
+    "martincjarvis",
     "metacharacters",
     "Meziantou",
     "mockups",

--- a/skills/repo-best-practices-bootstrap/references/checklist.md
+++ b/skills/repo-best-practices-bootstrap/references/checklist.md
@@ -506,6 +506,34 @@ This is enforced via branch protection (see 1.1 Branch Protection Rules).
 #     - id: conventional-pre-commit
 ```
 
+### 3.6 Auto-merge Configuration
+
+**Description:** Enable auto-merge to allow PRs to merge automatically when all required
+checks pass and reviews are approved.
+
+**Cost:** Free
+
+**Opt-out:** `code-quality` (category) or `auto-merge` (feature)
+
+**GitHub:**
+
+```bash
+# Check if auto-merge is enabled
+gh api repos/{owner}/{repo} --jq '.allow_auto_merge'
+
+# Enable auto-merge
+gh api repos/{owner}/{repo} --method PATCH -f allow_auto_merge=true
+
+# Usage: Enable auto-merge on a PR
+gh pr merge <N> --auto --squash
+```
+
+**Benefits:**
+
+- Reduces manual merge steps after approval
+- PRs merge immediately when all gates pass
+- Works with required reviews and status checks
+
 ## 4. Documentation Baseline
 
 ### 4.1 README.md


### PR DESCRIPTION
## Summary

- Add Section 3.6 Auto-merge Configuration to repo-best-practices-bootstrap checklist
- Add PR Review Requirements section to CLAUDE.md with persona-switching instructions
- Add Two-Account Workflow section to CONTRIBUTING.md documenting separation of duties

Closes #302

## Test plan

- [x] Auto-merge configuration documented in checklist ([checklist.md:L509-L535](https://github.com/mcj-coder/development-skills/blob/fix/302-auto-merge-persona-switching/skills/repo-best-practices-bootstrap/references/checklist.md#L509-L535))
- [x] PR Review Requirements added to CLAUDE.md ([CLAUDE.md:L104-L120](https://github.com/mcj-coder/development-skills/blob/fix/302-auto-merge-persona-switching/CLAUDE.md#L104-L120))
- [x] Two-Account Workflow documented in CONTRIBUTING.md ([CONTRIBUTING.md:L236-L258](https://github.com/mcj-coder/development-skills/blob/fix/302-auto-merge-persona-switching/CONTRIBUTING.md#L236-L258))
- [x] Auto-merge already enabled on repo ([verified via API](https://github.com/mcj-coder/development-skills/pull/371#issuecomment-3755624841))
- [x] Linting passes ([commit a87136c](https://github.com/mcj-coder/development-skills/commit/a87136c))

---

## For Reviewers

Reviewed files: CLAUDE.md, CONTRIBUTING.md, skills/repo-best-practices-bootstrap/references/checklist.md, cspell.json

Key verification points:
- Auto-merge section follows same format as other checklist items (Description, Cost, Opt-out, commands)
- PR Review Requirements section matches the persona-switching skill workflow
- Two-Account Workflow table clearly shows account separation duties
- martincjarvis added to cspell dictionary to support documentation
