### PR TITLE
docs: add scope change protocol and template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,40 @@ the complete workflow with proper plan formatting and approval.
 **Awaiting approval to proceed.**
 ```
 
+## Scope Changes
+
+When scope changes during implementation (adding, removing, or modifying requirements):
+
+1. **Post scope change comment** on the issue using the template below
+2. **Wait for approval** before making the change
+3. **Update issue body** with the approved change
+
+**Scope change comment format:**
+
+```markdown
+## Scope Change
+
+**Type:** Addition / Removal / Modification
+**Reason:** [Why the change is needed]
+**Impact:** [What this affects]
+
+**Changes:**
+
+- ~~Removed: [item]~~
+- Added: [item]
+
+**Awaiting approval to proceed with scope change.**
+```
+
+**After approval, update issue body:**
+
+- Added items: `- [ ] New item (added: [approval](link))`
+- Removed items: `- [ ] ~~Removed item~~ (descoped: [approval](link))`
+
+**Enforcement:** DangerJS Rule 3 fails PRs with descoped items missing approval links.
+
+See `skills/issue-driven-delivery/SKILL.md` for complete scope change protocol.
+
 ## Creating Skills
 
 ### Process Overview

--- a/skills/issue-driven-delivery/SKILL.md
+++ b/skills/issue-driven-delivery/SKILL.md
@@ -1742,9 +1742,42 @@ All scope changes during implementation MUST be tracked in acceptance criteria:
 
 **Adding scope:**
 
-1. Get approval in issue comment
-2. Add new checkbox with approval link
-3. Complete work and add evidence
+1. Post scope change comment (use template below)
+2. Get approval in issue comment thread
+3. Add new checkbox with approval link
+4. Complete work and add evidence
+
+**Removing scope (descoping):**
+
+1. Post scope change comment (use template below)
+2. Get approval in issue comment thread
+3. Strike through item and add approval link
+4. Item remains unchecked but struck through
+
+**Scope change without approval is a violation.** All added or removed work
+requires explicit approval captured in issue comments.
+
+#### Scope Change Comment Template
+
+When scope changes, post a comment using this format:
+
+```markdown
+## Scope Change
+
+**Type:** Addition / Removal / Modification
+**Reason:** [Why the change is needed]
+**Impact:** [What this affects - timeline, dependencies, etc.]
+
+**Changes:**
+
+- ~~Removed: [item being removed]~~
+- Added: [new item being added]
+- Modified: [item changed] → [new version]
+
+**Awaiting approval to proceed with scope change.**
+```
+
+After approval, update the issue body:
 
 Format for added scope:
 
@@ -1753,20 +1786,14 @@ Format for added scope:
 - [x] New requirement (added: [approval](#issuecomment-123), [evidence](commit-link))
 ```
 
-**Removing scope (descoping):**
-
-1. Get approval in issue comment
-2. Strike through item and add approval link
-3. Item remains unchecked but struck through
-
 Format for descoped items:
 
 ```markdown
 - [ ] ~~Original requirement~~ (descoped: [approval](#issuecomment-123))
 ```
 
-**Scope change without approval is a violation.** All added or removed work
-requires explicit approval captured in issue comments.
+**Exemplar:** [Issue #167](https://github.com/mcj-coder/development-skills/issues/167) demonstrates
+partial scope change compliance with documented scope reduction.
 
 ### Plan Lifecycle Evidence
 


### PR DESCRIPTION
## Summary

- Add Scope Change Comment Template to issue-driven-delivery skill
- Enhance Scope Change Tracking section with detailed workflow
- Add Scope Changes section to CONTRIBUTING.md
- Reference Issue #167 as partial exemplar

Closes #293

## Test plan

- [x] Scope change template documented ([SKILL.md:L1760-L1778](https://github.com/mcj-coder/development-skills/blob/fix/293-scope-change-documentation/skills/issue-driven-delivery/SKILL.md#L1760-L1778))
- [x] issue-driven-delivery skill updated ([SKILL.md:L1739-L1795](https://github.com/mcj-coder/development-skills/blob/fix/293-scope-change-documentation/skills/issue-driven-delivery/SKILL.md#L1739-L1795))
- [x] CONTRIBUTING.md updated ([CONTRIBUTING.md:L54-L85](https://github.com/mcj-coder/development-skills/blob/fix/293-scope-change-documentation/CONTRIBUTING.md#L54-L85))
- [x] Exemplar documented ([SKILL.md:L1794-L1795](https://github.com/mcj-coder/development-skills/blob/fix/293-scope-change-documentation/skills/issue-driven-delivery/SKILL.md#L1794-L1795))
- [x] Linting passes ([commit 13c2f03](https://github.com/mcj-coder/development-skills/commit/13c2f03))

---

## For Reviewers

Reviewed files: skills/issue-driven-delivery/SKILL.md, CONTRIBUTING.md

Key verification points:
- Scope change template provides clear structure for documenting changes
- Workflow steps (post comment → get approval → update issue) are clear
- CONTRIBUTING.md section provides concise summary with link to full protocol
- Issue #167 referenced as partial exemplar
