### PR TITLE
chore(ci): upgrade CodeQL action from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

- Upgrade CodeQL action from v3 to v4 to address deprecation warning

## Changes

- `github/codeql-action/init@v3` → `@v4`
- `github/codeql-action/analyze@v3` → `@v4`

## Test Plan

- [x] Lint passes ([evidence](https://github.com/mcj-coder/development-skills/actions/runs/21066851676/job/60586193395))
- [x] CI passes with CodeQL v4 ([evidence](https://github.com/mcj-coder/development-skills/actions/runs/21066851676/job/60586193391))

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)