### PR TITLE
docs: add skill format specification and references indexes

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -146,6 +146,7 @@
     "pyupgrade",
     "Qube",
     "queryability",
+    "RBPB",
     "rdeps",
     "reprioritize",
     "Reqnroll",

--- a/docs/SKILL-FORMAT.md
+++ b/docs/SKILL-FORMAT.md
@@ -1,0 +1,296 @@
+# Skill Format Specification
+
+This document defines the skill format for the development-skills repository, extending
+the [agentskills.io specification](https://agentskills.io/specification) with repository-specific
+conventions.
+
+## Directory Structure
+
+```text
+skills/<skill-name>/
+├── SKILL.md                    # Required: Main skill documentation
+├── <skill-name>.test.md        # Required: BDD tests for skill behavior
+├── <skill-name>.baseline.md    # Optional: Baseline verification checklist
+├── references/                 # Optional: Supporting documentation
+│   ├── README.md              # Required if references/ exists: Index of reference files
+│   └── <topic>.md             # Reference docs (self-contained)
+├── templates/                  # Optional: Reusable templates
+│   └── <template>.template     # Template files
+├── scripts/                    # Optional: Executable scripts
+│   ├── README.md              # Required if scripts/ exists: Index of scripts
+│   └── <script>.sh            # Script files
+└── examples/                   # Optional: Example implementations
+    └── <example>.md           # Example documentation
+```
+
+## SKILL.md Format
+
+### Required Frontmatter
+
+```yaml
+---
+name: skill-name
+description: >-
+  Use when [trigger conditions]. [What the skill does].
+  [Additional context about when to apply].
+---
+```
+
+### Extended Frontmatter (Recommended)
+
+```yaml
+---
+name: skill-name
+description: >-
+  Use when [trigger conditions]. [What the skill does].
+compatibility: Requires [prerequisites]
+metadata:
+  type: Process | Implementation | Platform | Quality
+  priority: P0 | P1 | P2 | P3 | P4
+---
+```
+
+### Frontmatter Fields
+
+| Field               | Required | Description                                                                   |
+| ------------------- | -------- | ----------------------------------------------------------------------------- |
+| `name`              | Yes      | Lowercase kebab-case. Must match directory name. Max 64 chars.                |
+| `description`       | Yes      | Trigger conditions and purpose. Max 1024 chars. Should start with "Use when". |
+| `compatibility`     | No       | Environment requirements (CLIs, platforms, dependencies).                     |
+| `metadata.type`     | No       | Skill category: Process, Implementation, Platform, Quality.                   |
+| `metadata.priority` | No       | Skill priority following the Priority Model (P0-P4).                          |
+
+### Priority Model
+
+Skills are classified by priority for conflict resolution:
+
+| Priority | Category                   | Description                                         |
+| -------- | -------------------------- | --------------------------------------------------- |
+| P0       | Safety & Integrity         | Security, immutability, provenance, traceability    |
+| P1       | Quality & Correctness      | Behavioral correctness, clean builds, test validity |
+| P2       | Consistency & Governance   | Conventions, versioning, pipeline conformance       |
+| P3       | Delivery & Flow            | Incremental execution, developer experience         |
+| P4       | Optimization & Convenience | Ergonomics, non-critical improvements               |
+
+When skills conflict: higher priority wins. If equal: prefer narrower scope. If scope equal:
+prefer stronger guardrails.
+
+### Skill Type Categories
+
+| Type           | Description                       | Examples                                           |
+| -------------- | --------------------------------- | -------------------------------------------------- |
+| Process        | Workflow and methodology guidance | TDD, issue-driven-delivery, skills-first-workflow  |
+| Implementation | Technology-specific patterns      | dotnet-efcore-practices, architecture-testing      |
+| Platform       | Platform/tooling integration      | automated-standards-enforcement, ci-cd-conformance |
+| Quality        | Code quality and standards        | broken-window, static-analysis-security            |
+
+## Required Sections
+
+Every SKILL.md must contain these sections in order:
+
+### 1. Title
+
+```markdown
+# Skill Name
+```
+
+Use title case. Must match the frontmatter `name` field (converted from kebab-case).
+
+### 2. Overview
+
+```markdown
+## Overview
+
+[2-4 sentences describing the skill's purpose and core value proposition]
+
+**REQUIRED:** [list of required prerequisite skills, if any]
+```
+
+### 3. When to Use
+
+```markdown
+## When to Use
+
+[Bullet list of trigger conditions when this skill should be activated]
+
+- Condition 1
+- Condition 2
+- **Opt-out offered:** [optional: when skill can be declined]
+```
+
+### 4. Core Workflow
+
+```markdown
+## Core Workflow
+
+[Numbered steps for the primary workflow]
+
+1. Step 1
+2. Step 2
+3. Step 3
+```
+
+## Recommended Sections
+
+### Prerequisites
+
+```markdown
+## Prerequisites
+
+- [Required tool or configuration]
+- [Required skill or capability]
+```
+
+### Red Flags - STOP
+
+```markdown
+## Red Flags - STOP
+
+- "Rationalization quote 1"
+- "Rationalization quote 2"
+```
+
+Use this section to identify anti-patterns or thoughts that indicate the skill is being
+circumvented.
+
+### Evidence Requirements
+
+```markdown
+## Evidence Requirements
+
+- [ ] Evidence item 1
+- [ ] Evidence item 2
+```
+
+### References
+
+```markdown
+## References
+
+- [Reference Name](references/reference-file.md) - Brief description
+- [External Resource](https://example.com) - Brief description
+```
+
+### Quick Reference
+
+```markdown
+## Quick Reference
+
+| Scenario | Action | Result    |
+| -------- | ------ | --------- |
+| Case 1   | Do X   | Y happens |
+```
+
+## Optional Sections
+
+These sections are included when relevant to the skill:
+
+- `## Detection and Deference` - When to defer to existing patterns
+- `## Decision Capture` - How decisions should be documented
+- `## Composition` - How this skill interacts with others
+- `## Success Criteria` - Measurable outcomes for skill application
+- `## Sample Commands` - Executable examples
+- `## Templates` - Inline or linked templates
+
+## Test File Format
+
+Every skill requires a colocated test file: `<skill-name>.test.md`
+
+```markdown
+# <Skill Name> - BDD Tests
+
+## Scenario: [Scenario Name]
+
+**Given:** [Initial state]
+**When:** [Action taken]
+**Then:** [Expected outcome]
+
+### Verification
+
+- [ ] [Specific verifiable outcome]
+- [ ] [Another verifiable outcome]
+```
+
+See [BDD Checklist Templates](references/bdd-checklist-templates.md) for detailed guidance.
+
+## References Directory
+
+When a skill has a `references/` directory, it must contain a `README.md` index:
+
+```markdown
+# References
+
+Index of reference documentation for the [skill-name] skill.
+
+## Contents
+
+| File                         | Description                  |
+| ---------------------------- | ---------------------------- |
+| [file-name.md](file-name.md) | Brief description of content |
+```
+
+## Self-Containment Principle
+
+Skills must be self-contained and deployable independently:
+
+**Required:**
+
+- All references must be to files within `skills/<skill-name>/`
+- Describe external concepts generically, not with repository-specific links
+- Platform-specific examples should cover GitHub, Azure DevOps, and Jira where applicable
+
+**Prohibited:**
+
+- References to `../../docs/` or other paths outside the skill folder
+- Links to repository-specific artifacts that may not exist when deployed elsewhere
+- Assumptions about repository structure beyond the skill folder
+
+## Validation Checklist
+
+Before committing a skill:
+
+- [ ] Frontmatter has required `name` and `description` fields
+- [ ] `name` matches directory name (lowercase kebab-case)
+- [ ] `description` starts with "Use when" trigger conditions
+- [ ] Overview section present (2-4 sentences)
+- [ ] When to Use section present with bullet list
+- [ ] Core Workflow section present with numbered steps
+- [ ] Test file exists: `<skill-name>.test.md`
+- [ ] No `../../` references in any files
+- [ ] All internal links resolve to files within skill folder
+- [ ] `references/README.md` exists if `references/` directory exists
+- [ ] Passes `npm run lint`
+
+## Examples
+
+### Minimal Valid Skill
+
+```yaml
+---
+name: example-skill
+description: Use when example conditions apply. Provides example guidance.
+---
+```
+
+```markdown
+# Example Skill
+
+## Overview
+
+Brief description of what this skill does and its core value.
+
+## When to Use
+
+- Example trigger condition
+
+## Core Workflow
+
+1. First step
+2. Second step
+3. Third step
+```
+
+### Complete Skill with Extensions
+
+See `skills/skills-first-workflow/SKILL.md` for a comprehensive example including
+all recommended sections.

--- a/docs/skill-dependency-matrix.md
+++ b/docs/skill-dependency-matrix.md
@@ -1,0 +1,318 @@
+# Skill Dependency Matrix
+
+This document maps relationships between skills in the development-skills repository,
+including dependencies on external Superpowers skills.
+
+## Skill Relationship Diagram
+
+```mermaid
+flowchart TB
+    subgraph External["Superpowers (External)"]
+        SP_US[using-superpowers]
+        SP_BR[brainstorming]
+        SP_WP[writing-plans]
+        SP_TDD[test-driven-development]
+        SP_VBC[verification-before-completion]
+        SP_SD[systematic-debugging]
+        SP_RCR[receiving-code-review]
+        SP_GW[using-git-worktrees]
+        SP_DPA[dispatching-parallel-agents]
+        SP_FDB[finishing-a-development-branch]
+    end
+
+    subgraph Process["Process Skills"]
+        SFW[skills-first-workflow]
+        PSR[process-skill-router]
+        RG[requirements-gathering]
+        IDD[issue-driven-delivery]
+        PP[pair-programming]
+    end
+
+    subgraph Foundation["Foundation Skills"]
+        ASE[automated-standards-enforcement]
+        GB[greenfield-baseline]
+        RBPB[repo-best-practices-bootstrap]
+        BW[broken-window]
+        AO[agents-onboarding]
+    end
+
+    subgraph Architecture["Architecture Skills"]
+        AT[architecture-testing]
+        CBC[component-boundary-ownership]
+        CCV[contract-consistency-validation]
+        SC[scoped-colocation]
+    end
+
+    subgraph Quality["Quality Skills"]
+        MA[markdown-author]
+        SAS[static-analysis-security]
+        QGE[quality-gate-enforcement]
+        CIC[ci-cd-conformance]
+    end
+
+    subgraph Delivery["Delivery Skills"]
+        AWA[agent-workitem-automation]
+        WSD[walking-skeleton-delivery]
+        TDP[technical-debt-prioritisation]
+        FDB[finishing-a-development-branch]
+    end
+
+    subgraph DotNet[".NET Skills"]
+        AIT[aspire-integration-testing]
+        TIT[testcontainers-integration-tests]
+    end
+
+    %% Core process flow
+    SFW --> SP_US
+    SFW --> SP_BR
+    SFW --> SP_WP
+    SFW --> SP_TDD
+    SFW --> SP_VBC
+
+    PSR --> RG
+    PSR --> SP_BR
+    PSR --> SP_WP
+    PSR --> SP_TDD
+    PSR --> SP_VBC
+
+    RG --> IDD
+    IDD --> SP_BR
+    IDD --> SP_WP
+    IDD --> SP_TDD
+    IDD --> SP_RCR
+    IDD --> SP_FDB
+
+    %% Foundation dependencies
+    ASE --> SP_VBC
+    ASE --> SP_TDD
+    GB --> SP_VBC
+    GB --> SP_TDD
+    GB --> IDD
+    RBPB --> SP_VBC
+    BW --> SP_VBC
+    BW --> SP_SD
+    BW --> SFW
+    AO --> SP_BR
+    AO --> SP_VBC
+
+    %% Architecture dependencies
+    AT --> SP_TDD
+    AT --> SP_VBC
+    CBC --> SP_BR
+    CBC --> SP_VBC
+    CCV --> SP_TDD
+    CCV --> SP_VBC
+    SC --> SP_VBC
+
+    %% Quality dependencies
+    SAS --> SP_VBC
+    QGE --> SP_VBC
+    QGE --> SP_TDD
+    CIC --> SP_VBC
+    CIC --> SP_BR
+
+    %% Delivery dependencies
+    AWA --> SP_BR
+    AWA --> SP_TDD
+    AWA --> SP_VBC
+    AWA --> IDD
+    WSD --> SP_TDD
+    WSD --> SP_VBC
+    TDP --> SP_VBC
+    FDB --> IDD
+
+    %% .NET dependencies
+    AIT --> SP_TDD
+    AIT --> SP_VBC
+    TIT --> SP_TDD
+    TIT --> SP_VBC
+
+    %% Pair programming
+    PP --> SP_GW
+    PP --> SP_DPA
+```
+
+## Dependency Matrix
+
+### External Dependencies (Superpowers)
+
+| development-skills Skill           | Required Superpowers Skills                                                                                                        |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| skills-first-workflow              | using-superpowers, brainstorming, writing-plans, test-driven-development, verification-before-completion                           |
+| process-skill-router               | brainstorming, writing-plans, test-driven-development, verification-before-completion, systematic-debugging, receiving-code-review |
+| issue-driven-delivery              | brainstorming, writing-plans, test-driven-development, receiving-code-review, finishing-a-development-branch                       |
+| agent-workitem-automation          | brainstorming, test-driven-development, verification-before-completion                                                             |
+| agents-onboarding                  | brainstorming, verification-before-completion                                                                                      |
+| best-practice-introduction         | brainstorming, verification-before-completion                                                                                      |
+| architecture-testing               | test-driven-development, verification-before-completion                                                                            |
+| aspire-integration-testing         | test-driven-development, verification-before-completion                                                                            |
+| automated-standards-enforcement    | test-driven-development, verification-before-completion                                                                            |
+| broken-window                      | verification-before-completion, systematic-debugging                                                                               |
+| branching-strategy-and-conventions | verification-before-completion                                                                                                     |
+| change-risk-rollback               | verification-before-completion, systematic-debugging                                                                               |
+| ci-cd-conformance                  | brainstorming, verification-before-completion                                                                                      |
+| component-boundary-ownership       | brainstorming, verification-before-completion                                                                                      |
+| contract-consistency-validation    | test-driven-development, verification-before-completion                                                                            |
+| deployment-provenance              | verification-before-completion                                                                                                     |
+| documentation-as-code              | verification-before-completion                                                                                                     |
+| greenfield-baseline                | test-driven-development, verification-before-completion                                                                            |
+| impacted-scope-enforcement         | verification-before-completion                                                                                                     |
+| incremental-change-impact          | verification-before-completion                                                                                                     |
+| library-extraction-stabilisation   | brainstorming                                                                                                                      |
+| local-dev-experience               | verification-before-completion                                                                                                     |
+| monorepo-orchestration-setup       | verification-before-completion                                                                                                     |
+| pair-programming                   | using-git-worktrees, dispatching-parallel-agents                                                                                   |
+| persona-switching                  | verification-before-completion                                                                                                     |
+| quality-gate-enforcement           | test-driven-development, verification-before-completion                                                                            |
+| release-tagging-plan               | verification-before-completion                                                                                                     |
+| repo-best-practices-bootstrap      | verification-before-completion                                                                                                     |
+| safe-brownfield-refactor           | test-driven-development, verification-before-completion                                                                            |
+| scoped-colocation                  | verification-before-completion                                                                                                     |
+| static-analysis-security           | verification-before-completion                                                                                                     |
+| technical-debt-prioritisation      | verification-before-completion                                                                                                     |
+| testcontainers-integration-tests   | test-driven-development, verification-before-completion                                                                            |
+| walking-skeleton-delivery          | test-driven-development, verification-before-completion                                                                            |
+
+### Internal Dependencies (development-skills)
+
+| Skill                          | Depends On             | Depended By                                                                                            |
+| ------------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| skills-first-workflow          | -                      | broken-window                                                                                          |
+| process-skill-router           | requirements-gathering | -                                                                                                      |
+| requirements-gathering         | issue-driven-delivery  | process-skill-router                                                                                   |
+| issue-driven-delivery          | -                      | requirements-gathering, agent-workitem-automation, greenfield-baseline, finishing-a-development-branch |
+| agent-workitem-automation      | issue-driven-delivery  | -                                                                                                      |
+| greenfield-baseline            | issue-driven-delivery  | -                                                                                                      |
+| finishing-a-development-branch | issue-driven-delivery  | -                                                                                                      |
+| broken-window                  | skills-first-workflow  | -                                                                                                      |
+
+## Invocation Order
+
+### Session Start
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant SFW as skills-first-workflow
+    participant US as using-superpowers
+    participant PSR as process-skill-router
+    participant Task as Task Skill
+
+    A->>SFW: Load first
+    SFW->>US: Verify loaded
+    SFW->>A: Prerequisites verified
+    A->>PSR: Determine task type
+    PSR->>Task: Route to appropriate skill
+```
+
+### New Work (No Ticket)
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant PSR as process-skill-router
+    participant RG as requirements-gathering
+    participant IDD as issue-driven-delivery
+    participant BR as brainstorming
+
+    A->>PSR: Check context
+    PSR->>RG: No ticket exists
+    RG->>A: Create ticket (STOP)
+    Note over A: Later session
+    A->>IDD: Ticket exists
+    IDD->>BR: Design phase
+    BR->>A: Continue implementation
+```
+
+### Existing Work (Ticket Exists)
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant PSR as process-skill-router
+    participant IDD as issue-driven-delivery
+    participant TDD as test-driven-development
+    participant VBC as verification-before-completion
+
+    A->>PSR: Check context
+    PSR->>IDD: Ticket exists
+    IDD->>TDD: Implementation phase
+    TDD->>VBC: Before claiming done
+    VBC->>A: Verified complete
+```
+
+## Skill Categories
+
+### Entry Points
+
+Skills that should be loaded first:
+
+1. **skills-first-workflow** - Session initialization
+2. **process-skill-router** - Task routing
+
+### Process Skills
+
+Skills that guide workflow methodology:
+
+- requirements-gathering
+- issue-driven-delivery
+- pair-programming
+- agent-workitem-automation
+
+### Foundation Skills
+
+Skills for repository setup:
+
+- greenfield-baseline
+- repo-best-practices-bootstrap
+- automated-standards-enforcement
+- agents-onboarding
+
+### Guard Skills
+
+Skills that prevent anti-patterns:
+
+- broken-window
+- quality-gate-enforcement
+- impacted-scope-enforcement
+
+## Incompatibility Notes
+
+### Mutual Exclusion
+
+| Skill A                | Skill B                  | Reason                                                              |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------- |
+| requirements-gathering | brainstorming            | RG creates tickets only; brainstorming designs for existing tickets |
+| greenfield-baseline    | safe-brownfield-refactor | Greenfield for new projects; brownfield for existing                |
+
+### Conditional Application
+
+| Primary Skill             | Secondary Skill        | Condition                          |
+| ------------------------- | ---------------------- | ---------------------------------- |
+| issue-driven-delivery     | requirements-gathering | Use RG first if no ticket exists   |
+| architecture-testing      | greenfield-baseline    | AT included in GB for new projects |
+| walking-skeleton-delivery | architecture-testing   | WSD may invoke AT for structure    |
+
+## Skill Loading Best Practices
+
+### Always Load
+
+These skills should be loaded at the start of every session:
+
+1. `skills-first-workflow` - Enforces prerequisite verification
+2. `process-skill-router` - Routes to correct skill based on context
+
+### Load on Demand
+
+These skills should be loaded when their trigger conditions match:
+
+- Implementation skills (architecture, testing, etc.)
+- Platform-specific skills (.NET, etc.)
+- Delivery skills (walking-skeleton, etc.)
+
+### Background Skills
+
+These skills provide background guidance but don't require explicit loading:
+
+- `broken-window` - Activated by warnings/errors
+- `impacted-scope-enforcement` - Activated during reviews

--- a/skills/agent-workitem-automation/references/README.md
+++ b/skills/agent-workitem-automation/references/README.md
@@ -1,0 +1,9 @@
+# References
+
+Reference materials for verification types and evidence requirements in agent work item automation.
+
+## Contents
+
+| File                                           | Description                                                                          |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [verification-types.md](verification-types.md) | Definitions and checklists for concrete changes vs process-only changes verification |

--- a/skills/agents-onboarding/references/README.md
+++ b/skills/agents-onboarding/references/README.md
@@ -1,0 +1,11 @@
+# References
+
+Reference materials for creating AGENTS.md files and onboarding AI agents to repositories.
+
+## Contents
+
+| File                                             | Description                                                                                                                |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| [AGENTS-TEMPLATE.md](AGENTS-TEMPLATE.md)         | Template for creating AGENTS.md files with placeholders for repository-specific content                                    |
+| [rationalizations.md](rationalizations.md)       | Common excuses for skipping agent onboarding and why they fail                                                             |
+| [standards-discovery.md](standards-discovery.md) | Guide for discovering existing standards in brownfield repositories by analyzing tooling, testing, and CI/CD configuration |

--- a/skills/architecture-testing/references/README.md
+++ b/skills/architecture-testing/references/README.md
@@ -1,0 +1,10 @@
+# References
+
+Reference materials for architecture testing patterns and NetArchTest implementation examples.
+
+## Contents
+
+| File                                                 | Description                                                                                                                            |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| [architecture-patterns.md](architecture-patterns.md) | Overview of architectural patterns including Clean Architecture, Hexagonal, Onion, Layered, and Modular Monolith with dependency rules |
+| [netarchtest-examples.md](netarchtest-examples.md)   | Code examples for NetArchTest library including boundary tests, namespace validation, and dependency rules                             |

--- a/skills/aspire-integration-testing/references/README.md
+++ b/skills/aspire-integration-testing/references/README.md
@@ -1,0 +1,10 @@
+# References
+
+Reference materials for .NET Aspire integration testing with the Aspire.Hosting.Testing package.
+
+## Contents
+
+| File                                                           | Description                                                                                                                                    |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| [aspire-hosting-testing-api.md](aspire-hosting-testing-api.md) | API reference for Aspire.Hosting.Testing including DistributedApplicationTestingBuilder, HTTP client creation, and connection string retrieval |
+| [aspire-testing-patterns.md](aspire-testing-patterns.md)       | Common testing patterns for Aspire applications including project setup, startup tests, and health endpoint validation                         |

--- a/skills/automated-standards-enforcement/references/README.md
+++ b/skills/automated-standards-enforcement/references/README.md
@@ -1,0 +1,13 @@
+# References
+
+Reference materials for implementing automated standards enforcement across CI, git hooks, and IDE integrations.
+
+## Contents
+
+| File                                       | Description                                                                                           |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| [ci-configuration.md](ci-configuration.md) | CI pipeline configuration for enforcing standards with clean build policy and GitHub Actions examples |
+| [git-hooks-setup.md](git-hooks-setup.md)   | Pre-commit hook configuration using Husky and lint-staged for fast, staged-only local validation      |
+| [ide-integration.md](ide-integration.md)   | IDE configuration using file-based settings like EditorConfig for consistent developer experience     |
+| [language-configs.md](language-configs.md) | Language-specific configuration examples for TypeScript, Python, and other ecosystems                 |
+| [tool-comparison.md](tool-comparison.md)   | Comprehensive comparison of linting, formatting, and enforcement tools by language and category       |

--- a/skills/best-practice-introduction/references/README.md
+++ b/skills/best-practice-introduction/references/README.md
@@ -1,0 +1,10 @@
+# References
+
+Reference materials for introducing best practices to teams with sustainable adoption patterns.
+
+## Contents
+
+| File                                       | Description                                                                                                |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| [rationalizations.md](rationalizations.md) | Common excuses for rushed rollouts and rebuttals explaining why phased adoption works better               |
+| [rollout-patterns.md](rollout-patterns.md) | Rollout strategy options including opt-in pilot, phased by team/component, and phased by enforcement level |

--- a/skills/branching-strategy-and-conventions/references/README.md
+++ b/skills/branching-strategy-and-conventions/references/README.md
@@ -1,0 +1,11 @@
+# References
+
+Reference materials for branching strategies, commit conventions, and merge workflows.
+
+## Contents
+
+| File                                           | Description                                                                                            |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| [branching-models.md](branching-models.md)     | Comparison of Trunk-Based Development, GitHub Flow, and Git Flow with workflows and selection criteria |
+| [commit-conventions.md](commit-conventions.md) | Conventional Commits format specification with type definitions, SemVer impact, and examples           |
+| [squash-merge-guide.md](squash-merge-guide.md) | Guide for constructing squash merge messages that preserve SemVer impact across multiple commits       |

--- a/skills/broken-window/references/README.md
+++ b/skills/broken-window/references/README.md
@@ -1,0 +1,10 @@
+# References
+
+Reference materials for the broken window principle including rationalizations and practical scenarios.
+
+## Contents
+
+| File                                       | Description                                                                                                       |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| [rationalizations.md](rationalizations.md) | Complete table of common excuses for ignoring broken windows and why they are wrong                               |
+| [scenarios.md](scenarios.md)               | Detailed examples with expected agent behavior when encountering broken windows like warnings and vulnerabilities |

--- a/skills/change-risk-rollback/references/README.md
+++ b/skills/change-risk-rollback/references/README.md
@@ -1,0 +1,11 @@
+# References
+
+Reference materials for deployment strategies, failure mode analysis, and rollback procedures.
+
+## Contents
+
+| File                                                 | Description                                                                                                         |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| [deployment-strategies.md](deployment-strategies.md) | Comparison of Blue-Green, Canary, Rolling, and Big-Bang deployment strategies with selection criteria               |
+| [failure-modes.md](failure-modes.md)                 | Comprehensive failure mode catalog by deployment type with symptom, detection, impact, and probability analysis     |
+| [rollback-templates.md](rollback-templates.md)       | Structured templates for defining rollback procedures including detection, decision criteria, and validation phases |

--- a/skills/ci-cd-conformance/references/README.md
+++ b/skills/ci-cd-conformance/references/README.md
@@ -1,0 +1,10 @@
+# References
+
+Reference materials for CI/CD conformance including brownfield migration and provider-specific configuration.
+
+## Contents
+
+| File                                                   | Description                                                                                                          |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| [brownfield-migration.md](brownfield-migration.md)     | Incremental migration guide for transitioning existing pipelines to full CI/CD conformance                           |
+| [provider-configuration.md](provider-configuration.md) | Provider-specific configuration for GitHub Actions including security features, quality gates, and release workflows |

--- a/skills/component-boundary-ownership/references/README.md
+++ b/skills/component-boundary-ownership/references/README.md
@@ -1,0 +1,9 @@
+# References
+
+Detailed guidance for component boundary decisions and organization patterns.
+
+## Contents
+
+| File                                         | Description                                                                                                                                |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [boundary-patterns.md](boundary-patterns.md) | Component boundary patterns including monorepo, polyrepo, and modular monolith organization strategies with boundary evaluation techniques |

--- a/skills/contract-consistency-validation/references/README.md
+++ b/skills/contract-consistency-validation/references/README.md
@@ -1,0 +1,10 @@
+# References
+
+Checklists and strategies for validating API contract changes and ensuring backward compatibility.
+
+## Contents
+
+| File                                                             | Description                                                                                                                    |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [breaking-change-checklist.md](breaking-change-checklist.md)     | Quick reference checklist for evaluating contract changes, classifying breaking vs safe changes, and SemVer decision guidance  |
+| [contract-testing-strategies.md](contract-testing-strategies.md) | Contract testing approaches including consumer-driven contracts (Pact) and provider contracts (OpenAPI, JSON Schema, Protobuf) |

--- a/skills/csharp-best-practices/references/README.md
+++ b/skills/csharp-best-practices/references/README.md
@@ -1,0 +1,13 @@
+# References
+
+C# language best practices organized by version, with the baseline standard and incremental deltas for each major release.
+
+## Contents
+
+| File                         | Description                                                                                                                                  |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| [csharp-10.md](csharp-10.md) | C# 10 best practices (.NET 6) - baseline standard covering core principles, file-scoped namespaces, global usings, and foundational patterns |
+| [csharp-11.md](csharp-11.md) | C# 11 best practices (.NET 7) - delta covering required members, raw string literals, list patterns, and file types                          |
+| [csharp-12.md](csharp-12.md) | C# 12 best practices (.NET 8) - delta covering primary constructors and collection expressions                                               |
+| [csharp-13.md](csharp-13.md) | C# 13 best practices (.NET 9) - delta covering params collections and partial properties/indexers                                            |
+| [csharp-14.md](csharp-14.md) | C# 14 best practices (.NET 10) - delta covering field-backed properties and extension members                                                |

--- a/skills/documentation-as-code/references/README.md
+++ b/skills/documentation-as-code/references/README.md
@@ -1,0 +1,13 @@
+# References
+
+Configuration guides and templates for implementing documentation-as-code with automated validation.
+
+## Contents
+
+| File                                                       | Description                                                                                         |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| [baseline-strategy.md](baseline-strategy.md)               | Strategy for adding documentation validation to existing repositories without blocking current work |
+| [markdown-linting.md](markdown-linting.md)                 | Markdownlint configuration with rule explanations, auto-fixable rules, and blocking rules           |
+| [spell-checking.md](spell-checking.md)                     | CSpell configuration for spell checking with technical dictionaries and ignore patterns             |
+| [templates.md](templates.md)                               | Documentation templates including ADR format and API documentation structure                        |
+| [validation-configuration.md](validation-configuration.md) | GitHub Actions workflow and link check configuration for CI/CD documentation validation             |

--- a/skills/dotnet-best-practices/references/README.md
+++ b/skills/dotnet-best-practices/references/README.md
@@ -1,0 +1,28 @@
+# References
+
+.NET platform best practices organized by version, covering runtime, SDK, ASP.NET Core, data access, and upgrade guidance.
+
+## Contents
+
+| File                                                     | Description                                                                                          |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [dotnet-6.md](dotnet-6.md)                               | .NET 6 LTS reference - stable baseline with sub-reference index                                      |
+| [dotnet-6-aspnetcore.md](dotnet-6-aspnetcore.md)         | ASP.NET Core in .NET 6 - minimal hosting conventions and Minimal APIs adoption                       |
+| [dotnet-6-data.md](dotnet-6-data.md)                     | Data and EF/ORM considerations in .NET 6 - instrumentation and query pattern guidance                |
+| [dotnet-6-runtime.md](dotnet-6-runtime.md)               | .NET 6 runtime and libraries - performance baselines and modern BCL API adoption                     |
+| [dotnet-6-sdk-tooling.md](dotnet-6-sdk-tooling.md)       | .NET 6 SDK and tooling - repo templates, analyzers, and Central Package Management planning          |
+| [dotnet-7.md](dotnet-7.md)                               | .NET 7 STS reference - observability improvements and runtime performance themes                     |
+| [dotnet-8.md](dotnet-8.md)                               | .NET 8 LTS reference - major release with substantial improvements and sub-reference index           |
+| [dotnet-8-aspnetcore.md](dotnet-8-aspnetcore.md)         | ASP.NET Core in .NET 8 - Minimal APIs standardization and output caching improvements                |
+| [dotnet-8-data.md](dotnet-8-data.md)                     | Data and EF Core in .NET 8 - query performance baselines and data access testing                     |
+| [dotnet-8-runtime.md](dotnet-8-runtime.md)               | .NET 8 runtime and libraries - performance re-baselining and AOT/trimming evaluation                 |
+| [dotnet-8-sdk-tooling.md](dotnet-8-sdk-tooling.md)       | .NET 8 SDK and tooling - SDK pinning and Central Package Management enforcement                      |
+| [dotnet-9.md](dotnet-9.md)                               | .NET 9 STS reference - SDK/tooling improvements and build output signal quality                      |
+| [dotnet-10.md](dotnet-10.md)                             | .NET 10 LTS reference - current recommended landing zone with sub-reference index                    |
+| [dotnet-10-aspnetcore.md](dotnet-10-aspnetcore.md)       | ASP.NET Core in .NET 10 - Identity metrics and Blazor static asset pipeline                          |
+| [dotnet-10-data-desktop.md](dotnet-10-data-desktop.md)   | Data, EF Core, and desktop workloads in .NET 10 - query plan improvements and deprecated API removal |
+| [dotnet-10-runtime.md](dotnet-10-runtime.md)             | .NET 10 runtime and base libraries - JIT/compiler improvements and GC refinements                    |
+| [dotnet-10-sdk-tooling.md](dotnet-10-sdk-tooling.md)     | .NET 10 SDK and tooling - SDK pinning and improved diagnostics                                       |
+| [dotnet-security-tooling.md](dotnet-security-tooling.md) | .NET-specific security tooling - NuGet auditing, CPM, public API governance, and Roslyn analyzers    |
+| [lts-upgrade-playbook.md](lts-upgrade-playbook.md)       | Practical guide for upgrading any .NET solution to the latest LTS with risk management               |
+| [upgrade-cumulative.md](upgrade-cumulative.md)           | Cumulative upgrade guidance for multi-major upgrades with consolidated checklist                     |

--- a/skills/dotnet-domain-primitives/references/README.md
+++ b/skills/dotnet-domain-primitives/references/README.md
@@ -1,0 +1,9 @@
+# References
+
+Implementation patterns for domain primitives and strongly typed identifiers in .NET.
+
+## Contents
+
+| File                                           | Description                                                                                          |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [strongly-typed-ids.md](strongly-typed-ids.md) | Source-generated strongly typed IDs using StronglyTypedId library with explicit boundary conversions |

--- a/skills/dotnet-efcore-practices/references/README.md
+++ b/skills/dotnet-efcore-practices/references/README.md
@@ -1,0 +1,9 @@
+# References
+
+EF Core migration organization and entity configuration patterns.
+
+## Contents
+
+| File                                                                               | Description                                                                                                       |
+| ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| [efcore-migrations-and-configurations.md](efcore-migrations-and-configurations.md) | Migrations project isolation, coverage exclusion strategies, and attribute-linked type configurations for EF Core |

--- a/skills/dotnet-healthchecks/references/README.md
+++ b/skills/dotnet-healthchecks/references/README.md
@@ -1,0 +1,9 @@
+# References
+
+Health check implementation guidance using community libraries.
+
+## Contents
+
+| File                                               | Description                                                                                         |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| [healthchecks-xabaril.md](healthchecks-xabaril.md) | AspNetCore.Diagnostics.HealthChecks (Xabaril) ecosystem for infrastructure dependency health checks |

--- a/skills/dotnet-logging-serilog/references/README.md
+++ b/skills/dotnet-logging-serilog/references/README.md
@@ -1,0 +1,9 @@
+# References
+
+Serilog integration patterns with Microsoft.Extensions.Logging.
+
+## Contents
+
+| File                                                     | Description                                                                                                             |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| [logging-serilog-ilogger.md](logging-serilog-ilogger.md) | ILogger and Serilog integration pattern ensuring startup failures are logged at Critical severity with bootstrap logger |

--- a/skills/dotnet-mapping-standard/references/README.md
+++ b/skills/dotnet-mapping-standard/references/README.md
@@ -1,0 +1,9 @@
+# References
+
+Source-generated object mapping patterns for .NET applications.
+
+## Contents
+
+| File                       | Description                                                                                              |
+| -------------------------- | -------------------------------------------------------------------------------------------------------- |
+| [mapperly.md](mapperly.md) | Mapperly source generator for DTO-to-domain and domain-to-DTO mapping with strongly typed ID conversions |

--- a/skills/dotnet-specification-pattern/references/README.md
+++ b/skills/dotnet-specification-pattern/references/README.md
@@ -1,0 +1,9 @@
+# References
+
+Reference materials for implementing the Specification pattern in .NET applications using Ardalis.Specification.
+
+## Contents
+
+| File                                                 | Description                                                                                                     |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| [specification-pattern.md](specification-pattern.md) | Recommended library (Ardalis.Specification) with usage examples and best practices for composing specifications |

--- a/skills/dotnet-testing-assertions/references/README.md
+++ b/skills/dotnet-testing-assertions/references/README.md
@@ -1,0 +1,9 @@
+# References
+
+Reference materials for writing expressive test assertions in .NET using AwesomeAssertions.
+
+## Contents
+
+| File                                           | Description                                                                                                                   |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| [awesome-assertions.md](awesome-assertions.md) | AwesomeAssertions library examples for equivalence checks, exception assertions, and best practices for structural assertions |

--- a/skills/impacted-scope-enforcement/references/README.md
+++ b/skills/impacted-scope-enforcement/references/README.md
@@ -1,0 +1,10 @@
+# References
+
+Reference materials for enforcing selective execution based on impacted components rather than running full validation suites.
+
+## Contents
+
+| File                                           | Description                                                                                                                             |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| [rationalizations.md](rationalizations.md)     | Common excuses for running full validation when selective execution is appropriate, with counterarguments and anti-patterns to avoid    |
+| [scoping-strategies.md](scoping-strategies.md) | Detailed patterns for scoping quality gates and deployments using git-based detection, monorepo tooling, and coverage delta calculation |

--- a/skills/incremental-change-impact/references/README.md
+++ b/skills/incremental-change-impact/references/README.md
@@ -1,0 +1,11 @@
+# References
+
+Reference materials for analyzing the impact of code changes and identifying affected components, tests, and documentation.
+
+## Contents
+
+| File                                             | Description                                                                                                                    |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| [dependency-analysis.md](dependency-analysis.md) | Techniques for tracing direct and indirect dependencies including code-level, configuration, reflection, and cascading effects |
+| [impact-matrix.md](impact-matrix.md)             | Templates for categorizing change types by impact level, risk assessment matrices, and common patterns by domain               |
+| [tooling.md](tooling.md)                         | Language-specific tools and cross-language utilities for dependency analysis, configuration scanning, and impact reporting     |

--- a/skills/issue-driven-delivery/references/README.md
+++ b/skills/issue-driven-delivery/references/README.md
@@ -1,0 +1,20 @@
+# References
+
+Reference materials for implementing issue-driven delivery workflows across GitHub, Azure DevOps, and Jira platforms.
+
+## Contents
+
+| File                                                 | Description                                                                                                                   |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| [assignment-workflow.md](assignment-workflow.md)     | Pull-based Kanban pattern for self-assignment, WIP limits, and handoff workflows between development phases                   |
+| [cli-commands.md](cli-commands.md)                   | Quick reference for GitHub, Azure DevOps, and Jira CLI commands covering state management, comments, and PRs                  |
+| [component-tagging.md](component-tagging.md)         | Tagging strategies for components, work types, priorities, and blocked status with platform-specific implementations          |
+| [evidence-requirements.md](evidence-requirements.md) | Standards for evidence formats including link requirements, checkbox formats, and verification checklists by change type      |
+| [issue-templates.md](issue-templates.md)             | Work-type-specific issue templates for bugs, features, enhancements, and technical debt across platforms                      |
+| [platform-resolution.md](platform-resolution.md)     | Domain pattern matching to identify the ticketing platform and appropriate CLI tool from taskboard URLs                       |
+| [prioritization-rules.md](prioritization-rules.md)   | Five-tier prioritization hierarchy including blocking task inheritance, circular dependency resolution, and enforcement rules |
+| [process-models.md](process-models.md)               | Kanban (default) and Scrum process models with ceremony integration points and sprint boundary handling                       |
+| [pr-reviews.md](pr-reviews.md)                       | PR review guidelines including inline comments, reviewer selection by change type, and iterative review process               |
+| [repo-tagging-template.md](repo-tagging-template.md) | Repository-specific tagging requirements template covering component, work type, priority, and blocked status tags            |
+| [state-tracking.md](state-tracking.md)               | Work item lifecycle states from New Feature through Grooming, Refinement, Implementation, Verification to Complete            |
+| [verification-types.md](verification-types.md)       | Distinguishing concrete changes (commit evidence) from process-only changes (analytical verification) with checklists         |

--- a/skills/library-extraction-stabilisation/references/README.md
+++ b/skills/library-extraction-stabilisation/references/README.md
@@ -1,0 +1,11 @@
+# References
+
+Reference materials for extracting, versioning, and governing shared libraries across multiple consumers.
+
+## Contents
+
+| File                                             | Description                                                                                                                        |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [governance-models.md](governance-models.md)     | Ownership models (dedicated team, rotating, community) and support models (SLA-based, best-effort) with documentation requirements |
+| [migration-planning.md](migration-planning.md)   | Incremental and big-bang migration strategies with pre-migration checklist, rollback procedures, and tracking templates            |
+| [versioning-strategy.md](versioning-strategy.md) | Semantic versioning guidelines, breaking change policy, deprecation workflow, support windows, and changelog format                |

--- a/skills/markdown-author/references/README.md
+++ b/skills/markdown-author/references/README.md
@@ -1,0 +1,11 @@
+# References
+
+Reference materials for markdown validation, spelling configuration, and editor integration.
+
+## Contents
+
+| File                                                   | Description                                                                                                             |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| [editor-integration.md](editor-integration.md)         | Configuration guides for VS Code, JetBrains, Vim/Neovim, and Emacs to enable real-time markdownlint and cspell feedback |
+| [spelling-configuration.md](spelling-configuration.md) | cspell configuration for locale-aware dictionaries, custom project terms, and language-specific code fence handling     |
+| [validation-rules.md](validation-rules.md)             | Complete markdownlint rules reference categorized by auto-fixable, blocking, and disabled rules with handling behavior  |

--- a/skills/persona-switching/references/README.md
+++ b/skills/persona-switching/references/README.md
@@ -1,0 +1,13 @@
+# References
+
+Reference materials for multi-identity Git/GitHub workflows with role-based personas and GPG signing.
+
+## Contents
+
+| File                                                     | Description                                                                                                                |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| [delegation-patterns.md](delegation-patterns.md)         | Decision matrix for persona switching vs sub-agent delegation with examples and context preservation guidelines            |
+| [persona-config-template.sh](persona-config-template.sh) | Shell configuration template with security profiles, input validation, lock management, and audit logging functions        |
+| [playbook-template.md](playbook-template.md)             | Repository-specific playbook template with quick reference commands, setup instructions, and troubleshooting guide         |
+| [security-profiles.md](security-profiles.md)             | Security profile configuration format, email/key requirements, token scoping recommendations, and customization guidelines |
+| [workflow-integration.md](workflow-integration.md)       | Integration with issue-driven-delivery phases, file-based context suggestions, and label-to-persona mapping                |

--- a/skills/quality-gate-enforcement/references/README.md
+++ b/skills/quality-gate-enforcement/references/README.md
@@ -1,0 +1,11 @@
+# References
+
+Reference materials for implementing quality gates including coverage thresholds, security scanning, and CI/CD integration.
+
+## Contents
+
+| File                                               | Description                                                                                                                        |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [brownfield-strategy.md](brownfield-strategy.md)   | Incremental quality gate adoption for existing codebases including coverage ratchet, security baselines, and flaky test management |
+| [pipeline-integration.md](pipeline-integration.md) | Platform-specific CI/CD configurations for GitHub Actions, Azure Pipelines, and GitLab CI with coverage and security scanning      |
+| [security-scanning.md](security-scanning.md)       | Comprehensive security scanning integration covering SAST, SCA, container scanning, DAST, and secret detection tools               |

--- a/skills/repo-best-practices-bootstrap/references/README.md
+++ b/skills/repo-best-practices-bootstrap/references/README.md
@@ -1,0 +1,11 @@
+# References
+
+Reference materials for bootstrapping repositories with security, quality, and documentation best practices.
+
+## Contents
+
+| File                                             | Description                                                                                                                                             |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [checklist.md](checklist.md)                     | Comprehensive checklist covering 8 mandatory categories plus optional features with platform-specific CLI commands for GitHub, Azure DevOps, and GitLab |
+| [cost-considerations.md](cost-considerations.md) | Feature availability by plan tier across platforms with free alternatives matrix and decision guidance for paid features                                |
+| [platform-detection.md](platform-detection.md)   | Detection scripts for identifying hosting platform from git remote URLs with CLI tool requirements and authentication verification                      |

--- a/skills/requirements-gathering/references/README.md
+++ b/skills/requirements-gathering/references/README.md
@@ -1,0 +1,14 @@
+# References
+
+Reference materials for requirements gathering, including decomposition formats, platform
+integration, and scope detection patterns.
+
+## Contents
+
+| File                                                                 | Description                                                                                                                  |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [decomposition-formats.md](decomposition-formats.md)                 | Formats for presenting ticket decomposition proposals including outline view, details table, and dependency graphs           |
+| [examples.md](examples.md)                                           | Practical examples of requirements gathering conversations and resulting tickets for features, bugs, refactoring, and skills |
+| [platform-cli-examples.md](platform-cli-examples.md)                 | CLI commands for creating tickets, epics, and linking dependencies on GitHub, Azure DevOps, and Jira                         |
+| [platform-organization-options.md](platform-organization-options.md) | Options for organizing epics, child tickets, and dependencies across different platforms with ADR templates                  |
+| [scope-detection.md](scope-detection.md)                             | Techniques for detecting when work items are too large and should be decomposed into multiple tickets                        |

--- a/skills/security-processes/references/README.md
+++ b/skills/security-processes/references/README.md
@@ -1,0 +1,14 @@
+# References
+
+Reference materials for security process implementation including dependency scanning,
+SAST, release gates, and supply chain security.
+
+## Contents
+
+| File                                                               | Description                                                                                                    |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| [dependency-scanning.md](dependency-scanning.md)                   | Controls for detecting vulnerable dependencies early and continuously with SCA scanners and exception policies |
+| [dependency-update-governance.md](dependency-update-governance.md) | Controls for managing risk from dependency changes while maintaining high patch velocity                       |
+| [release-gates-and-policy.md](release-gates-and-policy.md)         | Enforceable, auditable security gates for releases including minimum gates and exception handling              |
+| [sast.md](sast.md)                                                 | Static Application Security Testing controls for detecting insecure coding patterns early in CI                |
+| [supply-chain-and-sbom.md](supply-chain-and-sbom.md)               | Controls for increasing visibility and integrity of delivered artifacts through SBOMs and artifact scanning    |

--- a/skills/skills-first-workflow/references/README.md
+++ b/skills/skills-first-workflow/references/README.md
@@ -1,0 +1,10 @@
+# References
+
+Reference materials for implementing skills-first workflow including AGENTS.md templates and autofix behavior documentation.
+
+## Contents
+
+| File                                     | Description                                                                                                     |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| [AGENTS-TEMPLATE.md](AGENTS-TEMPLATE.md) | Template for creating or updating AGENTS.md in repositories that adopt skills-first workflow                    |
+| [AUTOFIX.md](AUTOFIX.md)                 | Detailed autofix behavior for each verification check including Superpowers installation and AGENTS.md creation |

--- a/skills/static-analysis-security/references/README.md
+++ b/skills/static-analysis-security/references/README.md
@@ -1,0 +1,12 @@
+# References
+
+Reference materials for static analysis security implementation including CI configuration,
+secrets detection, and tool selection guides.
+
+## Contents
+
+| File                                         | Description                                                                                                     |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| [ci-configuration.md](ci-configuration.md)   | CI/CD pipeline configurations for security scanning across GitHub Actions, Azure DevOps, GitLab CI, and Jenkins |
+| [secrets-detection.md](secrets-detection.md) | Guide for preventing accidental exposure of credentials with tool setup, custom patterns, and incident response |
+| [tool-selection.md](tool-selection.md)       | SAST tool selection criteria and comparison across languages with recommended tool combinations                 |

--- a/skills/technical-debt-prioritisation/references/README.md
+++ b/skills/technical-debt-prioritisation/references/README.md
@@ -1,0 +1,12 @@
+# References
+
+Reference materials for technical debt prioritisation including effort estimation, impact
+assessment, and risk quantification frameworks.
+
+## Contents
+
+| File                                             | Description                                                                                                              |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| [effort-estimation.md](effort-estimation.md)     | Framework for measuring work required to address technical debt including scoring scales and quick win identification    |
+| [impact-assessment.md](impact-assessment.md)     | Framework for measuring the cost of technical debt to business, developers, and users with evidence requirements         |
+| [risk-quantification.md](risk-quantification.md) | Framework for measuring probability and severity of harm from unaddressed technical debt across multiple risk categories |

--- a/skills/testcontainers-integration-tests/references/README.md
+++ b/skills/testcontainers-integration-tests/references/README.md
@@ -1,0 +1,12 @@
+# References
+
+Reference materials for Testcontainers integration testing including CI/CD setup,
+language-specific configuration, and performance optimization.
+
+## Contents
+
+| File                                                       | Description                                                                                                            |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| [ci-cd-integration.md](ci-cd-integration.md)               | CI/CD pipeline configurations for Testcontainers across GitHub Actions, GitLab CI, Azure DevOps, Jenkins, and CircleCI |
+| [language-setup.md](language-setup.md)                     | Language-specific Testcontainers setup guides for .NET, Java, Python, and Node.js with shared fixture patterns         |
+| [performance-optimization.md](performance-optimization.md) | Container lifecycle strategies, test isolation patterns, and parallel execution configuration for optimal performance  |

--- a/skills/walking-skeleton-delivery/references/README.md
+++ b/skills/walking-skeleton-delivery/references/README.md
@@ -1,0 +1,11 @@
+# References
+
+Reference materials for walking skeleton delivery including pattern examples, scope management, and technology spike distinction.
+
+## Contents
+
+| File                                                               | Description                                                                                                        |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| [examples-by-pattern.md](examples-by-pattern.md)                   | Walking skeleton examples for new microservices, technology validation, and distributed systems with BDD scenarios |
+| [pitfalls-and-scope-creep.md](pitfalls-and-scope-creep.md)         | Common rationalizations, scope creep patterns, and prevention checklists for keeping skeletons minimal             |
+| [technology-spike-distinction.md](technology-spike-distinction.md) | Key distinctions between technology spikes and walking skeletons with decision framework and common mistakes       |


### PR DESCRIPTION
## Summary

Phase 1 of Skills Repository Improvement Plan - Documentation & Standards Foundation:

- Created `docs/SKILL-FORMAT.md` defining skill structure standards extending agentskills.io spec
- Created `docs/skill-dependency-matrix.md` with Mermaid diagrams showing skill relationships
- Added `references/README.md` index files to all 37 skill directories with references folders
- Added RBPB abbreviation to cspell dictionary

## Issues

- Refs: #379
- Closes #379

## Test Plan

- [x] `npm run lint` - All checks pass ([evidence](https://github.com/mcj-coder/development-skills/actions/runs/21069690808/job/60595751358))
- [x] All 37 references/README.md files created and indexed ([evidence](https://github.com/mcj-coder/development-skills/pull/380/files))
- [x] New documentation files follow markdown standards ([evidence](https://github.com/mcj-coder/development-skills/pull/380/commits/c89b2d0d30592486022ce83c5b5212df8927c285))

## Verification

- Commit SHA: c89b2d0
- All lint checks pass
- Pre-commit hooks passed (prettier, markdownlint, cspell, secretlint)

## Auto-merge

- [ ] Enable auto-merge after required approvals and checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)