### PR TITLE
fix: Add missing required sections to 28 non-compliant skills

### DIFF
--- a/skills/agent-workitem-automation/SKILL.md
+++ b/skills/agent-workitem-automation/SKILL.md
@@ -20,6 +20,25 @@ all times. If you cannot prove context or tooling, stop and fix that first.
 If an issue-driven workflow is required (work item comments, approvals, evidence tracking),
 use `issue-driven-delivery`.
 
+## When to Use
+
+- Agent is asked to autonomously manage a work item (GitHub, Azure DevOps, or Jira)
+- Comment mentions the agent with a task verb (e.g., "manage", "handle", "take", "own")
+- Need to resolve task board source, platform CLI, or step updates
+- Automating delivery flow across ticketing systems
+- Setting up CI/CD workflows triggered by ticket events
+
+## Core Workflow
+
+1. **Discovery**: Read README.md, locate Work Items section, infer platform from URL
+2. **Setup**: Verify CLI is installed and authenticated for the platform
+3. **Load ticket**: Fetch issue details, comments, acceptance criteria, and related PRs
+4. **Execute step**: Determine and execute only the next required step
+5. **Post update**: Comment with Summary, Evidence, Next Step, and Hand-off status
+6. **Update checklist**: Mark completed items in the issue body
+7. **Verify completion**: Use verification-before-completion for all acceptance criteria
+8. **Close or hand-off**: Close when complete with evidence, or hand off to human if blocked
+
 ## End-to-End Autonomous Delivery Flow
 
 Autonomous delivery follows four explicit phases:

--- a/skills/agents-onboarding/SKILL.md
+++ b/skills/agents-onboarding/SKILL.md
@@ -18,6 +18,14 @@ must understand how to work in the repository by reading only AGENTS.md.
 **REQUIRED SUB-SKILL:** `superpowers:brainstorming`
 **REQUIRED SUB-SKILL:** `superpowers:verification-before-completion`
 
+## When to Use
+
+- User integrates AI agents into repository for first time
+- User asks to set up agent guidance, rules, or onboarding documentation
+- Repository is missing agent-specific onboarding docs (no AGENTS.md)
+- Fresh agent context needs to understand repository standards without conversation history
+- Existing AGENTS.md is incomplete or outdated and needs enhancement
+
 ## Core Workflow
 
 1. **Announce** skill and why it applies.

--- a/skills/broken-window/SKILL.md
+++ b/skills/broken-window/SKILL.md
@@ -24,6 +24,16 @@ objective and measurable—there is no "spirit vs letter" escape.
 - Standards violations detected during code review
 - Skills-first repos: Before starting work (validate prerequisites)
 
+## Core Workflow
+
+1. Detect warning, error, or standards violation
+2. Investigate root cause and document finding
+3. Estimate fix time and remaining work time
+4. Apply 2x rule: if fix time < 2x remaining work, fix immediately
+5. If fix time >= 2x remaining work, create tech-debt issue with steps to replicate
+6. Verify warning/error is resolved or issue is created
+7. Continue with original task
+
 ## The 2x Rule
 
 ```dot

--- a/skills/component-boundary-ownership/SKILL.md
+++ b/skills/component-boundary-ownership/SKILL.md
@@ -17,6 +17,15 @@ components) to scoped-colocation.
 
 **REQUIRED:** superpowers:brainstorming, superpowers:verification-before-completion
 
+## When to Use
+
+- User decides repository organization or restructures codebase
+- User asks where functionality should live (component placement decisions)
+- User reviews or questions existing component boundaries
+- New functionality spans multiple existing components
+- Team ownership changes require boundary realignment
+- Deployment independence needs evaluation for splitting/merging components
+
 ## Core Workflow
 
 1. **Identify candidate boundaries** based on deployment independence, team ownership, coupling analysis, and reuse patterns

--- a/skills/csharp-best-practices/SKILL.md
+++ b/skills/csharp-best-practices/SKILL.md
@@ -16,6 +16,25 @@ detects the language/runtime configuration, prefers the newest supported feature
 consults version-specific references progressively from C# 10 upward while respecting
 repository conventions.
 
+## When to Use
+
+- Implementing or refactoring C# code in any .NET project
+- Reviewing C# code for best practice alignment
+- Upgrading code to use newer C# language features
+- Resolving analyzer warnings or style issues
+- Onboarding to an existing C# codebase to understand effective patterns
+
+## Core Workflow
+
+1. **Detect language version**: Check LangVersion in csproj, Directory.Build.props, or infer from TFM
+2. **Record determination**: Document effective C# version and how it was determined
+3. **Load references progressively**: Load reference docs from C# 10 up to the effective version
+4. **Apply highest-priority guidance**: When conflicts exist, newest version guidance wins
+5. **Handle optional analyzers**: Pause and request clarification for optional/contentious rules
+6. **Apply to touched code only**: Avoid unrelated formatting changes unless broader refactor requested
+7. **Validate build and tests**: Ensure changes compile and pass tests
+8. **Emit summary**: Document applied practices and any pending analyzer decisions
+
 ## Intent
 
 Apply C# best practices appropriate to the project's **effective language version**.

--- a/skills/dotnet-bespoke-code-minimisation/SKILL.md
+++ b/skills/dotnet-bespoke-code-minimisation/SKILL.md
@@ -9,13 +9,26 @@ Bias against bespoke internal implementations by preferring mature open-source t
 composable libraries. When custom code is unavoidable, enforce justification rubrics that
 require explicit rationale, ownership, versioning, testing, and security considerations.
 
+## When to Use
+
+- Proposals to write internal mappers, code generators, custom build scripts, or DI containers
+- Reviews where new internal tooling or bespoke framework layers are introduced
+- Evaluating whether to build vs buy/adopt for any infrastructure component
+- Reviewing PRs that add custom implementations for common concerns (validation, retries, caching)
+- Architectural decisions involving custom scaffolding or automation scripts
+
+## Core Workflow
+
+1. **Identify the concern**: Determine what functionality is being proposed (mapping, validation, CLI, etc.)
+2. **Search for OSS alternatives**: Evaluate mature open-source libraries that solve the same problem
+3. **Compare trade-offs**: Assess maintenance burden, test effort, performance, and community support
+4. **Apply decision framework**: Choose OSS unless clear justification exists for bespoke code
+5. **Require justification rubric**: If bespoke code is proposed, demand explicit rationale,
+   ownership, versioning, tests, and security considerations
+6. **Document decision**: Record OSS evaluation, selection rationale, and maintenance plan
+7. **Verify in PR**: Check that PR includes evidence of OSS evaluation and rubric satisfaction
+
 ## Core
-
-### When to use
-
-- Proposals to write internal mappers, code generators, custom build scripts, custom DI containers,
-  or bespoke framework layers.
-- Reviews where new internal tooling is introduced.
 
 ### Defaults
 

--- a/skills/dotnet-best-practices/SKILL.md
+++ b/skills/dotnet-best-practices/SKILL.md
@@ -50,6 +50,16 @@ Use this skill when you are:
 
 For cross-language or organization-wide security processes, use the `security-processes` skill alongside this one.
 
+## Core Workflow
+
+1. Identify target .NET version and load corresponding version reference
+2. For upgrades, load upgrade-cumulative.md and lts-upgrade-playbook.md
+3. Apply baseline engineering standards (security, reliability, performance, maintainability)
+4. Review code against version-specific recommended patterns
+5. Validate configuration centralisation and analyzer enforcement
+6. Produce target framework recommendation and adoption checklist
+7. Document risks, breaking changes, and required test gates
+
 ## Progressive loading model
 
 1. Read this file (baseline standards + operating procedure).

--- a/skills/dotnet-domain-primitives/SKILL.md
+++ b/skills/dotnet-domain-primitives/SKILL.md
@@ -10,12 +10,25 @@ domain models. Conversions to/from primitives are permitted only at explicit bou
 (persistence, transport, serialization), ensuring type safety and validation throughout
 the domain layer.
 
+## When to Use
+
+- Designing or reviewing domain models (entities, aggregates, commands/events)
+- Introducing new entity identifiers (CustomerId, OrderId, TenantId, etc.)
+- Working with meaningful primitives that carry validation (EmailAddress, Money, Percentage)
+- Reviewing code where primitive types (Guid, string, int) are used for domain concepts
+- Implementing API boundaries, persistence layers, or serialization
+
+## Core Workflow
+
+1. **Identify primitive obsession**: Locate places where Guid, string, int, or long represent domain concepts
+2. **Define strongly typed IDs**: Create typed ID types using source-generation libraries for entity identifiers
+3. **Define value objects**: Create value objects for meaningful primitives with validation (EmailAddress, Money)
+4. **Establish boundary conversions**: Map to/from primitives only at explicit boundaries (API, persistence, transport)
+5. **Configure serialization**: Add JSON converters, EF Core value converters, and type handlers as needed
+6. **Update service signatures**: Change service methods to accept domain primitives, not raw types
+7. **Add boundary tests**: Test that boundary conversion works and invalid primitives are rejected
+
 ## Core
-
-### When to use
-
-- Designing or reviewing domain models (entities, aggregates, commands/events).
-- Any non-trivial service where identifiers and "meaningful primitives" recur across layers.
 
 ### Defaults (non-negotiable)
 

--- a/skills/dotnet-efcore-practices/SKILL.md
+++ b/skills/dotnet-efcore-practices/SKILL.md
@@ -9,12 +9,26 @@ Standardise Entity Framework Core usage with dedicated migrations projects exclu
 coverage, attribute-linked configuration types for entities, and deterministic configuration
 discovery. This ensures clean separation between business logic and infrastructure scaffolding.
 
+## When to Use
+
+- Any solution using EF Core for persistence
+- Adding or modifying DbContext, entity types, or configurations
+- Creating or updating EF Core migrations
+- Setting up code coverage exclusions for infrastructure projects
+- Reviewing PRs that change persistence layer structure
+
+## Core Workflow
+
+1. **Verify project structure**: Ensure migrations are in a dedicated `*.Persistence.Migrations` project
+2. **Configure coverage exclusion**: Add `<ExcludeFromCodeCoverage>true</ExcludeFromCodeCoverage>` to migrations project
+3. **Create configuration types**: Implement dedicated `IEntityTypeConfiguration<T>` for each entity
+4. **Link via attributes**: Use attribute-based discovery to connect entities to their configurations
+5. **Keep DbContext clean**: DbContext applies configurations, not define them inline
+6. **Ensure deterministic ordering**: Configuration scanning uses stable ordering (e.g., by full name)
+7. **Verify coverage gate**: Run tests to confirm migrations project excluded from coverage reports
+8. **Add repository tests**: Use xUnit with `IAsyncLifetime` for async repository testing
+
 ## Core
-
-### When to use
-
-- Any solution using EF Core for persistence.
-- Any PR introducing or changing DbContext, entity types, configurations, or migrations.
 
 ### Defaults (non-negotiable)
 

--- a/skills/dotnet-healthchecks/SKILL.md
+++ b/skills/dotnet-healthchecks/SKILL.md
@@ -9,12 +9,25 @@ Standardise health check implementation using the AspNetCore.Diagnostics.HealthC
 open-source ecosystem. Prefer battle-tested packages over bespoke probes for liveness, readiness,
 and dependency health endpoints across databases, caches, message brokers, and external services.
 
+## When to Use
+
+- Building or modifying ASP.NET Core services that need health endpoints
+- Adding health checks for infrastructure dependencies (databases, caches, brokers)
+- Implementing Kubernetes liveness and readiness probes
+- Reviewing PRs that introduce custom health check implementations
+- Configuring orchestration health semantics for containerised services
+
+## Core Workflow
+
+1. **Evaluate Xabaril packages**: Check if AspNetCore.Diagnostics.HealthChecks has a package for the dependency
+2. **Register health checks**: Add checks via `AddHealthChecks()` with appropriate packages
+3. **Separate liveness from readiness**: Tag liveness checks with "live", readiness with "ready"
+4. **Map endpoints**: Configure `/health/live` and `/health/ready` with tag-based predicates
+5. **Configure orchestration**: Set Kubernetes probes to use appropriate endpoints
+6. **Test health checks**: Unit test custom IHealthCheck implementations, integration test endpoints
+7. **Verify with curl**: Use `curl -i` to confirm endpoints return expected status codes
+
 ## Core
-
-### When to use
-
-- Any ASP.NET Core service exposing liveness, readiness, or dependency health endpoints.
-- Any PR introducing health checks for infrastructure dependencies.
 
 ### Defaults (strong preference)
 

--- a/skills/dotnet-logging-serilog/SKILL.md
+++ b/skills/dotnet-logging-serilog/SKILL.md
@@ -6,6 +6,28 @@ metadata:
   superseded-by: observability-logging-baseline
 ---
 
+## Overview
+
+This skill standardizes structured logging in .NET applications using `ILogger`/`ILogger<T>`
+abstractions with Serilog as the underlying provider. It ensures startup exceptions are logged at
+Critical severity for immediate visibility in operational tooling, and provides patterns for
+Application Insights and OpenTelemetry integration.
+
+## When to Use
+
+- Building or modifying ASP.NET Core or worker service applications that need structured logging
+- Reviewing PRs that touch host startup, logging configuration, or exception handling
+- Integrating logging with Azure Application Insights or OpenTelemetry
+- Ensuring startup failures are properly captured and visible in monitoring systems
+
+## Core Workflow
+
+1. Configure Serilog as the logging provider during host building with a bootstrap logger for early startup capture
+2. Use `ILogger<T>` abstractions in application code (never reference Serilog types directly)
+3. Wrap host build/run in try/catch and log startup exceptions at Critical severity
+4. Configure appropriate sinks (console for dev, Application Insights or centralized sink for production)
+5. Verify structured properties are used instead of string concatenation for operational fields
+
 > **DEPRECATED**: This skill has been consolidated into `observability-logging-baseline`.
 >
 > - For comprehensive observability guidance (logs, metrics, traces), use

--- a/skills/dotnet-mapping-standard/SKILL.md
+++ b/skills/dotnet-mapping-standard/SKILL.md
@@ -9,11 +9,25 @@ Standardise mapping between DTOs, domain models, and persistence models using so
 mappers. Mappings live at explicit boundaries (API, infrastructure) with deterministic,
 testable conversion paths and no runtime reflection magic.
 
+## When to Use
+
+- Mapping between API request/response DTOs and domain models
+- Converting domain entities to/from persistence models
+- Handling integration event contracts at service boundaries
+- Reviewing PRs that introduce new mapping logic
+- Refactoring existing reflection-based mappers to source-generated alternatives
+
+## Core Workflow
+
+1. **Identify mapping boundaries**: Locate where DTOs cross into domain or persistence layers
+2. **Choose source-generated mapper**: Select Mapperly or similar compile-time mapper
+3. **Create explicit mappers**: Implement mapper classes at boundary projects (API, Infrastructure)
+4. **Handle typed IDs explicitly**: Map strongly typed IDs and value objects with explicit conversions
+5. **Apply DI gating rules**: Use static mappers unless mapper has injected dependencies
+6. **Add mapping tests**: Include round-trip tests for critical boundary conversions
+7. **Verify side-effect free**: Ensure mappings have no side effects or external calls
+
 ## Core
-
-### When to use
-
-- Any service that maps between API contracts, domain models, persistence models, or integration events.
 
 ### Defaults
 

--- a/skills/dotnet-open-source-first-governance/SKILL.md
+++ b/skills/dotnet-open-source-first-governance/SKILL.md
@@ -9,13 +9,26 @@ Enforce open-source-first dependency selection with mandatory live license reval
 review time. Historical OSS status is insufficient; verify current licensing via web search
 for every dependency selection, upgrade, or review to catch recent licensing changes.
 
+## When to Use
+
+- Selecting a new library or tool dependency
+- Upgrading any dependency (minor or major version)
+- Performing PR, architecture, security, or dependency reviews
+- Evaluating alternatives for an existing proprietary or source-available component
+- Auditing existing dependencies for license compliance
+
+## Core Workflow
+
+1. **Prefer open-source**: Default to OSS libraries over proprietary or source-available alternatives
+2. **Perform live web search**: Search for current licensing status (not cached/historical data)
+3. **Verify authoritative sources**: Check project homepage, LICENSE file, release notes, issue tracker
+4. **Confirm exact version license**: Verify licensing for the specific version being adopted
+5. **Check transitive dependencies**: Spot-check critical transitives for license changes
+6. **Document verification**: Record license name, verification source(s), and verification date (UTC)
+7. **Gate on missing verification**: Reject or defer proposals without complete license documentation
+8. **Flag ambiguity**: Mark dependency unapproved if licensing cannot be verified confidently
+
 ## Core
-
-### When to use
-
-- Selecting a new dependency.
-- Upgrading any dependency (minor or major).
-- Performing PR, architecture, security, or dependency reviews.
 
 ### Policy (non-negotiable)
 

--- a/skills/dotnet-source-generation-first/SKILL.md
+++ b/skills/dotnet-source-generation-first/SKILL.md
@@ -10,6 +10,23 @@ concerns like mapping, serialization, regex, and logging. Source generation prov
 determinism, compile-time verification, reduced runtime overhead, and better AOT/trimming
 compatibility.
 
+## When to Use
+
+- Introducing or reviewing repetitive cross-cutting mechanisms (mappers, serializers, regex, logging templates)
+- Building performance-sensitive systems or services with startup-time concerns
+- Targeting AOT compilation or assembly trimming scenarios
+- Evaluating mapping or serialization libraries for a new project
+- Reviewing PRs that propose reflection-based or runtime codegen approaches
+
+## Core Workflow
+
+1. Identify the cross-cutting concern (mapping, serialization, regex, logging)
+2. Check if a source-generation library exists for the use case (e.g., Mapperly, System.Text.Json source generators, GeneratedRegex)
+3. Evaluate the source-gen library against requirements (API compatibility, feature set, maintainability)
+4. Implement using the source-generation approach
+5. Verify compile-time generation is working (check generated files, no runtime reflection warnings)
+6. Benchmark if performance is critical (use the minimal benchmark template in Load: advanced)
+
 ## Core
 
 ### When to use

--- a/skills/dotnet-specification-pattern/SKILL.md
+++ b/skills/dotnet-specification-pattern/SKILL.md
@@ -9,6 +9,23 @@ Prefer the Specification Pattern over generic Repository Pattern for query compo
 domain selection logic. Specifications define what to fetch while infrastructure decides how
 to execute, enabling composable, testable selection logic without exposing ORM details.
 
+## When to Use
+
+- Implementing query logic beyond trivial CRUD (filtering, paging, sorting, includes)
+- Building systems with multiple query shapes or evolving selection logic
+- Reviewing code that introduces generic repository patterns with GetAll/Find methods
+- Refactoring scattered LINQ queries in handlers or controllers
+- Adding tenancy, authorization, or other cross-cutting query constraints
+
+## Core Workflow
+
+1. Identify selection logic that is reused or non-trivial
+2. Create a named specification class implementing ISpecification<T>
+3. Define criteria, includes, ordering, and paging in the specification
+4. Update repository to accept specifications (ListAsync, CountAsync)
+5. Replace inline LINQ chains with the named specification
+6. Compose specifications using And/Or combinators where needed
+
 ## Core
 
 ### When to use

--- a/skills/dotnet-testing-assertions/SKILL.md
+++ b/skills/dotnet-testing-assertions/SKILL.md
@@ -9,6 +9,24 @@ Standardise test assertions on open-source libraries, preferring AwesomeAssertio
 community fork of FluentAssertions) for fluent, readable assertions with better error
 messages. Enforce OSS license revalidation for all test dependencies.
 
+## When to Use
+
+- Establishing or reviewing test conventions for a new project
+- Introducing or upgrading assertion libraries in existing projects
+- Migrating from FluentAssertions to AwesomeAssertions
+- Reviewing PRs that add new test dependencies
+- Evaluating assertion library license compliance
+
+## Core Workflow
+
+1. Verify the assertion library is open-source (check license)
+2. Add AwesomeAssertions package reference to test projects
+3. Update using statements to reference AwesomeAssertions namespace
+4. Write fluent assertions using Should() extension methods
+5. Use BeEquivalentTo for DTOs with exclusions for generated fields
+6. Use BeCloseTo for time assertions to avoid brittle exact matches
+7. Run tests to verify assertions work correctly
+
 ## Core
 
 ### When to use

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -21,6 +21,16 @@ principles by ensuring verification and role-based reviews complete BEFORE pull 
 - Ready to integrate changes into main branch
 - Need guidance on next steps (PR, merge, cleanup)
 
+## Core Workflow
+
+1. Verify implementation complete: tests pass, changes committed, branch pushed
+2. Check verification requirements: detect changed file types and determine required reviews
+3. Complete pre-PR verification: QA verification and role-based reviews in work item
+4. Post evidence to work item with links to verification comments
+5. Choose integration path: direct merge, create PR, or abandon
+6. Execute chosen path with appropriate commands
+7. Post-integration: update work item state, post final evidence, delete feature branch
+
 ## Prerequisites
 
 Before using this skill:

--- a/skills/innersource-governance-bootstrap/SKILL.md
+++ b/skills/innersource-governance-bootstrap/SKILL.md
@@ -9,6 +9,24 @@ Establish InnerSource governance in repositories to enable internal open-source 
 patterns. Provides standardised contribution workflows, community documentation templates,
 ownership models, and transparent decision-making processes within an organisation.
 
+## When to Use
+
+- Setting up a new repository that will follow InnerSource principles
+- Converting an existing repository to InnerSource governance model
+- Establishing contribution guidelines for internal open-source projects
+- Bootstrapping community documentation (CONTRIBUTING, CODE_OF_CONDUCT, etc.)
+- Defining maintainer responsibilities and ownership models
+
+## Core Workflow
+
+1. Create required documentation files (README.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, CODEOWNERS, GOVERNANCE.md)
+2. Configure CODEOWNERS with appropriate team assignments and component ownership
+3. Set up branch protection requiring CODEOWNERS approval and status checks
+4. Configure issue and PR templates with required sections
+5. Document review turnaround expectations and decision-making processes
+6. Enable and configure CI/CD to run on all PRs
+7. Announce InnerSource status to potential contributors
+
 ## Core
 
 ### When to use

--- a/skills/observability-logging-baseline/SKILL.md
+++ b/skills/observability-logging-baseline/SKILL.md
@@ -9,6 +9,24 @@ Establish production-ready observability foundations using OpenTelemetry standar
 structured logging with message templates, RED/USE metrics, distributed tracing with W3C
 Trace Context, and correlation ID propagation across service boundaries.
 
+## When to Use
+
+- Building any service requiring production-ready observability
+- Establishing logging, metrics, and tracing patterns for new services
+- Upgrading existing services from unstructured to structured observability
+- Reviewing PRs that introduce or modify observability instrumentation
+- Making architecture decisions involving monitoring and observability tooling
+
+## Core Workflow
+
+1. Configure structured logging with message templates (not string interpolation)
+2. Add correlation ID middleware to propagate request context
+3. Set up OpenTelemetry SDK for metrics and tracing
+4. Implement RED metrics (Rate, Errors, Duration) for HTTP endpoints
+5. Enable W3C Trace Context propagation for distributed tracing
+6. Configure OTLP exporter for vendor-portable telemetry export
+7. Validate log output contains structured fields and correlation IDs
+
 ## Core
 
 ### When to use

--- a/skills/pair-programming/SKILL.md
+++ b/skills/pair-programming/SKILL.md
@@ -37,6 +37,15 @@ Do not use when:
 - High-stakes decisions needing real-time human judgement
 - Learning/teaching scenarios where collaboration is the goal
 
+## Core Workflow
+
+1. Trigger: Acknowledge receipt, validate Definition of Ready, request clarification if needed
+2. Planning: Create implementation plan, identify sub-tasks and dependencies, post summary to issue
+3. Implementation: Dispatch sub-agents by skill domain, work in isolated worktrees, coordinate via issue comments
+4. Review Loop: Run tests, request persona-based reviews (Tech Lead, QA, Security), iterate until all pass
+5. Human Checkpoint: Create PR with comprehensive description, wait for human review
+6. Merge: Squash merge on approval, close issue with evidence, archive plan, proceed to next issue
+
 ## Workflow Phases
 
 ```text

--- a/skills/persona-switching/SKILL.md
+++ b/skills/persona-switching/SKILL.md
@@ -36,6 +36,16 @@ switch to appropriate role | suggest persona for this phase]."
 | Workflow      | issue-driven-delivery phase transition              | Suggest appropriate persona for phase     |
 | Role mismatch | Current persona doesn't match task context          | Recommend persona switch                  |
 
+## Core Workflow
+
+1. Check for existing persona configuration in target repo
+2. If missing: run Setup Flow (role discovery, security profile configuration, artifact generation)
+3. Source the persona config script for current session
+4. Use `use_persona <role>` to switch to appropriate persona for current task
+5. Verify switch with `show_persona` and `gh auth status`
+6. Perform work under the switched persona identity
+7. Switch back to appropriate persona when task context changes
+
 ## Detection Logic
 
 1. Check for existing `docs/playbooks/persona-switching.md` in target repo

--- a/skills/process-skill-router/SKILL.md
+++ b/skills/process-skill-router/SKILL.md
@@ -13,7 +13,7 @@ skill addresses the skill selection loophole where agents may load `brainstormin
 
 **Core principle**: Evaluate context, recommend appropriate skill, provide rationale.
 
-## When to Use This Skill
+## When to Use
 
 Use process-skill-router when:
 

--- a/skills/requirements-gathering/SKILL.md
+++ b/skills/requirements-gathering/SKILL.md
@@ -12,7 +12,7 @@ understanding WHAT needs to be built and WHY, not HOW to build it.
 
 **Core principle**: Gather requirements, create ticket, stop. No design, no plan, no commits.
 
-## When to Use This Skill
+## When to Use
 
 Use requirements-gathering when:
 

--- a/skills/safe-brownfield-refactor/SKILL.md
+++ b/skills/safe-brownfield-refactor/SKILL.md
@@ -24,6 +24,13 @@ code without destabilising production systems.
 - Improving code quality in systems with high change risk
 - Working with code that has implicit dependencies or undocumented behaviour
 
+## Core Workflow
+
+1. Understanding: Map dependencies, identify risks using assessment matrix, find seams, write characterisation tests
+2. Preparation: Add monitoring, create rollback plan, set up feature flags if needed, establish baseline metrics
+3. Execution: Make one atomic change at a time, run tests after each change, deploy frequently, monitor closely
+4. Verification: Compare before/after metrics, validate characterisation tests pass, remove scaffolding, update documentation
+
 ## Core Principles
 
 ### 1. Characterisation Tests First

--- a/skills/scoped-colocation/SKILL.md
+++ b/skills/scoped-colocation/SKILL.md
@@ -25,6 +25,15 @@ should not need to navigate across multiple unrelated directories.
 - Onboarding to an unfamiliar codebase
 - Adding tests, styles, or related assets to existing features
 
+## Core Workflow
+
+1. Identify the owning feature or domain for the code
+2. Place code in that feature's directory (not in shared/utils)
+3. Colocate tests with implementation in the same directory
+4. Colocate related assets (styles, types, fixtures) with the feature
+5. Extract to shared only when genuinely shared (3+ consumers)
+6. Verify directory structure reflects feature boundaries
+
 ## Core Patterns
 
 ### Pattern 1: Feature-Scoped Directories

--- a/skills/security-processes/SKILL.md
+++ b/skills/security-processes/SKILL.md
@@ -13,6 +13,25 @@ metadata:
 Organization-grade security governance across languages and platforms. This skill defines
 security policies, processes, and exception handling at the organizational level.
 
+## When to Use
+
+- Defining organisation-wide security policies and governance standards
+- Establishing SCA (Software Composition Analysis) and SBOM requirements
+- Configuring dependency scanning and update governance processes
+- Setting up release gates and security policy enforcement
+- Defining remediation SLAs and exception handling procedures
+- Reviewing or auditing security processes across repositories
+
+## Core Workflow
+
+1. Define security controls matrix by repository type and deployment model
+2. Configure baseline security pipeline (dependency scan, SAST, secret scan, SBOM)
+3. Establish minimum security gates for PRs and releases
+4. Document remediation SLAs by severity (Critical: 24h, High: 7d, Medium: 30d, Low: 90d)
+5. Create exception request and approval workflow
+6. Set up security scan evidence templates for compliance documentation
+7. Configure pipeline stages appropriate to each environment (dev/staging/prod)
+
 ## Security Skills Decision Matrix
 
 Use this matrix to select the appropriate security skill:

--- a/skills/testing-strategy-agnostic/SKILL.md
+++ b/skills/testing-strategy-agnostic/SKILL.md
@@ -73,6 +73,16 @@ For a complete .NET testing implementation:
 - Reviewing changes that impact solution structure, public interfaces, or integration contracts.
 - Introducing or tightening E2E/system testing and their operational criteria.
 
+## Core Workflow
+
+1. Select appropriate testing skill using the decision tree (this skill for strategy, others for implementation)
+2. Define test tiers: unit tests (isolated, fast), system tests (real wiring, stubbed externals), E2E tests (minimal, high-value)
+3. Establish architecture testing rules for layering, dependencies, and conventions
+4. Define contract versioning and public API governance policies
+5. Configure observability requirements with payload logging constraints
+6. Create quality gates with appropriate thresholds for each tier
+7. Document acceptance criteria using provided templates
+
 ## Core Principles
 
 - **Layered test pyramid** (Unit → System → E2E).

--- a/skills/testing-strategy-dotnet/SKILL.md
+++ b/skills/testing-strategy-dotnet/SKILL.md
@@ -12,6 +12,25 @@ testing (unit, system, E2E), BDD practices using Reqnroll, architecture enforcem
 NetArchTest, and public API governance for published libraries. Enforces observability
 criteria and payload logging constraints.
 
+## When to Use
+
+- Implementing or reviewing a .NET testing approach for a new solution
+- Establishing test project naming and colocation conventions
+- Introducing tiered testing (unit, system, E2E) to an existing codebase
+- Adding architecture tests to enforce structural patterns
+- Reviewing test tier selection and mocking boundaries in PRs
+- Configuring CI pipelines for test execution
+
+## Core Workflow
+
+1. Create test projects following naming conventions (ComponentName.UnitTest, ComponentName.SystemTest, ComponentName.E2E)
+2. Colocate test projects with the component they validate
+3. Implement unit tests with xUnit and Moq for isolated class/method testing
+4. Implement system tests with BDD style (Reqnroll) mocking only external dependencies
+5. Implement E2E tests with Testcontainers for transient infrastructure
+6. Add architecture tests using NetArchTest to enforce layering rules
+7. Configure CI matrix to run appropriate test tiers per stage (PR, mainline, post-deploy)
+
 ## Intent
 
 Define a consistent .NET testing architecture with:


### PR DESCRIPTION
## Summary

- Added missing "When to Use" section to 4 skills
- Added missing "Core Workflow" section to 8 skills
- Added both missing sections to 15 skills
- Added all 3 required sections (Overview, When to Use, Core Workflow) to 1 skill

All 55 skills now pass `npm run validate:skills`.

## Issues

- Closes #390

## Test Plan

- [x] `npm run validate:skills` - All 55 skills pass ([evidence](https://github.com/mcj-coder/development-skills/issues/390))
- [x] `npm run lint` - All checks pass ([evidence](https://github.com/mcj-coder/development-skills/pull/391/checks))

## Skills Modified (28 total)

### Missing only "When to Use" (4)
- agents-onboarding
- component-boundary-ownership
- process-skill-router
- requirements-gathering

### Missing only "Core Workflow" (8)
- broken-window
- dotnet-best-practices
- finishing-a-development-branch
- pair-programming
- persona-switching
- safe-brownfield-refactor
- scoped-colocation
- testing-strategy-agnostic

### Missing both sections (15)
- agent-workitem-automation
- csharp-best-practices
- dotnet-bespoke-code-minimisation
- dotnet-domain-primitives
- dotnet-efcore-practices
- dotnet-healthchecks
- dotnet-mapping-standard
- dotnet-open-source-first-governance
- dotnet-source-generation-first
- dotnet-specification-pattern
- dotnet-testing-assertions
- innersource-governance-bootstrap
- observability-logging-baseline
- security-processes
- testing-strategy-dotnet

### Missing all 3 sections (1)
- dotnet-logging-serilog

🤖 Generated with [Claude Code](https://claude.com/claude-code)