### PR TITLE
chore(ci): make skill validation blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
   skill-validation:
     name: Skill Structure Validation
     runs-on: ubuntu-latest
-    continue-on-error: true # TODO: Remove once skills comply with SKILL-FORMAT.md
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Removes `continue-on-error: true` from skill-validation CI job
- All 55 skills now comply with SKILL-FORMAT.md per PR #391
- Skill validation will now block PRs that introduce non-compliant skills

## Issues

- Closes #393

## Test Plan

- [x] `npm run validate:skills` - All 55 skills pass ([evidence](https://github.com/mcj-coder/development-skills/pull/391))
- [x] CI job will fail for non-compliant skills ([evidence](https://github.com/mcj-coder/development-skills/pull/392/checks))