### PR TITLE
feat(skills): add priority and type metadata to all skill frontmatter

### DIFF
--- a/skills/agent-workitem-automation/SKILL.md
+++ b/skills/agent-workitem-automation/SKILL.md
@@ -4,6 +4,9 @@ description: >
   Use when an agent is asked to autonomously manage a work item and must
   resolve task board source, platform CLI, or step updates across GitHub,
   Azure DevOps, or Jira.
+metadata:
+  type: Platform
+  priority: P3
 ---
 
 # Agent Work Item Automation

--- a/skills/agents-onboarding/SKILL.md
+++ b/skills/agents-onboarding/SKILL.md
@@ -3,8 +3,8 @@ name: agents-onboarding
 description: Use when user integrates agents into repository, asks to set up agent guidance/rules/onboarding, or repo missing agent-specific onboarding docs (AGENTS.md). Ensures fresh agent context can apply all repo standards and external skills.
 compatibility: Requires Superpowers skill system to be installed
 metadata:
-  type: Foundation
-  priority: P0 (Safety & Integrity)
+  type: Platform
+  priority: P3
 ---
 
 # Agents-Onboarding

--- a/skills/architecture-testing/SKILL.md
+++ b/skills/architecture-testing/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: architecture-testing
 description: Use when user mentions architectural boundaries, layering, dependency rules, project structure constraints, or asks to define/review/enforce architecture. For new apps, check if production quality/best practices/specific pattern requested.
+metadata:
+  type: Implementation
+  priority: P1
 ---
 
 # Architecture Testing

--- a/skills/aspire-integration-testing/SKILL.md
+++ b/skills/aspire-integration-testing/SKILL.md
@@ -4,6 +4,9 @@ description: >-
   Use when repository includes .NET Aspire usage, distributed application setup, or
   cross-component behavior validation. Produces BDD-style integration tests with health
   checks and observability verification.
+metadata:
+  type: Implementation
+  priority: P1
 ---
 
 # Aspire Integration Testing

--- a/skills/automated-standards-enforcement/SKILL.md
+++ b/skills/automated-standards-enforcement/SKILL.md
@@ -3,7 +3,7 @@ name: automated-standards-enforcement
 description: Use when creating or modifying any repository to establish automated quality enforcement (linting, spelling, tests, SAST, security). Applies by default unless user explicitly refuses. Ensures clean build policy with minimal developer friction.
 metadata:
   type: Platform
-  priority: P0
+  priority: P2
 ---
 
 # Automated Standards Enforcement

--- a/skills/best-practice-introduction/SKILL.md
+++ b/skills/best-practice-introduction/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: best-practice-introduction
 description: Use when introducing new standards, tooling, practices, or asking for adoption/rollout guidance. Produces phased rollout plan with adoption criteria, risk assessment, and rollback triggers.
+metadata:
+  type: Process
+  priority: P3
 ---
 
 # Best Practice Introduction

--- a/skills/branching-strategy-and-conventions/SKILL.md
+++ b/skills/branching-strategy-and-conventions/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: branching-strategy-and-conventions
 description: Use when creating any repository, defining Git workflows, or enforcing commit conventions. Establishes branching policy, commit message standards (Conventional Commits), and merge rules aligned to SemVer.
+metadata:
+  type: Process
+  priority: P2
 ---
 
 # Branching Strategy and Conventions

--- a/skills/broken-window/SKILL.md
+++ b/skills/broken-window/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: broken-window
 description: Use when warnings/errors occur during git operations, package management, builds, or when reviewing completed work for standards violations. Fix immediately unless impact doubles delivery time.
+metadata:
+  type: Quality
+  priority: P1
 ---
 
 # Broken Window

--- a/skills/change-risk-rollback/SKILL.md
+++ b/skills/change-risk-rollback/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: change-risk-rollback
 description: Use when planning release, deployment, or infrastructure changes. Produces risk assessment with failure modes, impact rating, rollback procedures, and prerequisite execution criteria before deployment.
+metadata:
+  type: Process
+  priority: P1
 ---
 
 # Change Risk & Rollback

--- a/skills/ci-cd-conformance/SKILL.md
+++ b/skills/ci-cd-conformance/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: ci-cd-conformance
 description: Use when user creates/modifies CI/CD pipelines, mentions deployment automation, quality gates, or release processes. Applies to all repositories by default to ensure platform-specific best practices (dependency scanning, secret detection, protected branches).
+metadata:
+  type: Platform
+  priority: P2
 ---
 
 # CI/CD Conformance

--- a/skills/component-boundary-ownership/SKILL.md
+++ b/skills/component-boundary-ownership/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: component-boundary-ownership
 description: Use when user decides repository organization, where functionality should live, or reviews component boundaries. Determines cross-component ownership and placement (macro), delegates intra-component file layout to scoped-colocation (micro).
+metadata:
+  type: Implementation
+  priority: P2
 ---
 
 # Component Boundary Ownership

--- a/skills/contract-consistency-validation/SKILL.md
+++ b/skills/contract-consistency-validation/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: contract-consistency-validation
 description: Use when user modifies public interfaces/APIs, changes behavior of exposed methods, or requests compatibility checks. Validates breaking changes, requires user confirmation, enforces SemVer, and mandates ADR for pre-1.0 relaxations or v1+ exceptions.
+metadata:
+  type: Quality
+  priority: P1
 ---
 
 # Contract Consistency Validation

--- a/skills/csharp-best-practices/SKILL.md
+++ b/skills/csharp-best-practices/SKILL.md
@@ -5,6 +5,9 @@ description: >-
   project's effective C# language version and .NET target/runtime. Detect the language/runtime,
   prefer the newest supported features, and consult version-specific references progressively
   from C# 10 upward.
+metadata:
+  type: Implementation
+  priority: P2
 ---
 
 # C# Best Practices (Version-Aware Skill)

--- a/skills/deployment-provenance/SKILL.md
+++ b/skills/deployment-provenance/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: deployment-provenance
 description: Use when deploying software to production or staging environments to ensure complete traceability of what was deployed, when, by whom, and from which source. Essential for audit compliance, incident investigation, and rollback decisions.
+metadata:
+  type: Platform
+  priority: P0
 ---
 
 # Deployment Provenance

--- a/skills/documentation-as-code/SKILL.md
+++ b/skills/documentation-as-code/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: documentation-as-code
 description: Use when user creates/modifies/reviews documentation (Markdown, ADRs, plans, READMEs). Applies same rigor as code with lint, spell, format validation, review processes, and CI automation.
+metadata:
+  type: Implementation
+  priority: P2
 ---
 
 # Documentation as Code

--- a/skills/dotnet-bespoke-code-minimisation/SKILL.md
+++ b/skills/dotnet-bespoke-code-minimisation/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dotnet-bespoke-code-minimisation
 description: Bias against bespoke scripts/frameworks by default; prefer mature open-source tools and composable libraries with clear ownership.
+metadata:
+  type: Implementation
+  priority: P2
 ---
 
 ## Overview

--- a/skills/dotnet-best-practices/SKILL.md
+++ b/skills/dotnet-best-practices/SKILL.md
@@ -5,6 +5,9 @@ description: >
   codebases. Covers architecture, runtime/framework choices, SDK/tooling, packaging, deployment
   strategy, and version-aware best practices, including code review and ongoing maintenance
   scenarios.
+metadata:
+  type: Implementation
+  priority: P2
 ---
 
 # .NET best practices (version-aware, progressive-loading)

--- a/skills/dotnet-domain-primitives/SKILL.md
+++ b/skills/dotnet-domain-primitives/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dotnet-domain-primitives
 description: Prevent primitive obsession by enforcing StronglyTypedIds and value objects in domain models and at boundaries.
+metadata:
+  type: Implementation
+  priority: P2
 ---
 
 ## Overview

--- a/skills/dotnet-efcore-practices/SKILL.md
+++ b/skills/dotnet-efcore-practices/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dotnet-efcore-practices
 description: Standardise EF Core usage: isolate migrations in a dedicated project excluded from code coverage, and enforce attribute-linked dedicated type configuration classes.
+metadata:
+  type: Implementation
+  priority: P2
 ---
 
 ## Overview

--- a/skills/dotnet-healthchecks/SKILL.md
+++ b/skills/dotnet-healthchecks/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dotnet-healthchecks
 description: Standardise health check implementation using the AspNetCore.Diagnostics.HealthChecks open-source ecosystem.
+metadata:
+  type: Implementation
+  priority: P2
 ---
 
 ## Overview

--- a/skills/dotnet-logging-serilog/SKILL.md
+++ b/skills/dotnet-logging-serilog/SKILL.md
@@ -2,6 +2,8 @@
 name: dotnet-logging-serilog
 description: Standardise logging on ILogger with Serilog as the provider; ensure startup exceptions are logged as Critical.
 metadata:
+  type: Implementation
+  priority: P2
   status: deprecated
   superseded-by: observability-logging-baseline
 ---

--- a/skills/dotnet-mapping-standard/SKILL.md
+++ b/skills/dotnet-mapping-standard/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dotnet-mapping-standard
 description: Standardise mapping (DTOs/contracts/persistence models) using source-generated mappers and explicit boundary conversions.
+metadata:
+  type: Implementation
+  priority: P2
 ---
 
 ## Overview

--- a/skills/dotnet-open-source-first-governance/SKILL.md
+++ b/skills/dotnet-open-source-first-governance/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dotnet-open-source-first-governance
 description: Enforce open-source-first dependency selection with mandatory live license revalidation (web search) and review-time gating.
+metadata:
+  type: Implementation
+  priority: P0
 ---
 
 ## Overview

--- a/skills/dotnet-source-generation-first/SKILL.md
+++ b/skills/dotnet-source-generation-first/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dotnet-source-generation-first
 description: Prefer compile-time source generation over runtime evaluation for repetitive cross-cutting concerns (mapping, logging, regex, etc.).
+metadata:
+  type: Implementation
+  priority: P2
 ---
 
 ## Overview

--- a/skills/dotnet-specification-pattern/SKILL.md
+++ b/skills/dotnet-specification-pattern/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dotnet-specification-pattern
 description: Prefer Specification Pattern for query composition and domain selection logic; avoid generic Repository Pattern duplication of ORM semantics.
+metadata:
+  type: Implementation
+  priority: P2
 ---
 
 ## Overview

--- a/skills/dotnet-testing-assertions/SKILL.md
+++ b/skills/dotnet-testing-assertions/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dotnet-testing-assertions
 description: Standardise unit/integration test assertions on open-source libraries; prefer AwesomeAssertions over non-open-source alternatives.
+metadata:
+  type: Implementation
+  priority: P1
 ---
 
 ## Overview

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -3,6 +3,9 @@ name: finishing-a-development-branch
 description: >-
   Use when implementation is complete, all tests pass, and you need to decide how to integrate the work -
   guides completion of development work by presenting structured options for merge, PR, or cleanup
+metadata:
+  type: Process
+  priority: P3
 ---
 
 # Finishing a Development Branch

--- a/skills/impacted-scope-enforcement/SKILL.md
+++ b/skills/impacted-scope-enforcement/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: impacted-scope-enforcement
 description: Use when user deploys changes, commits code, runs builds/tests, or requests selective validation. Ensures only impacted components are tested/deployed when appropriate, scoping quality gates to modified code.
+metadata:
+  type: Quality
+  priority: P1
 ---
 
 # Impacted Scope Enforcement

--- a/skills/incremental-change-impact/SKILL.md
+++ b/skills/incremental-change-impact/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: incremental-change-impact
 description: Use when user proposes changes, refactoring, or feature additions; asks about impact, affected components, or what needs testing; or before making structural changes. Identifies blast radius and cascading effects.
+metadata:
+  type: Process
+  priority: P3
 ---
 
 # Incremental Change Impact

--- a/skills/innersource-governance-bootstrap/SKILL.md
+++ b/skills/innersource-governance-bootstrap/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: innersource-governance-bootstrap
 description: Use when establishing InnerSource governance in a repository to enable internal open-source collaboration patterns, standardised contribution workflows, and community-driven development practices within an organisation.
+metadata:
+  type: Platform
+  priority: P2
 ---
 
 ## Overview

--- a/skills/issue-driven-delivery/SKILL.md
+++ b/skills/issue-driven-delivery/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: issue-driven-delivery
 description: Use when work is tied to a ticketing system work item and requires comment approval, sub-task tracking, or CLI-based delivery workflows.
+metadata:
+  type: Process
+  priority: P2
 ---
 
 # Issue-Driven Delivery

--- a/skills/library-extraction-stabilisation/SKILL.md
+++ b/skills/library-extraction-stabilisation/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: library-extraction-stabilisation
 description: Use when shared code is used by 3+ components, user asks about extracting library, or code is copied across services. Ensures stability, ownership, versioning, and governance before extraction.
+metadata:
+  type: Implementation
+  priority: P3
 ---
 
 # Library Extraction Stabilisation

--- a/skills/local-dev-experience/SKILL.md
+++ b/skills/local-dev-experience/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: local-dev-experience
 description: Use when setting up or optimizing local development environments for fast feedback loops. Applies to any project where iteration speed matters. Covers hot reload, incremental builds, test filtering, IDE optimization, and multi-service local development patterns.
+metadata:
+  type: Platform
+  priority: P4
 ---
 
 # Local Dev Experience

--- a/skills/markdown-author/SKILL.md
+++ b/skills/markdown-author/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: markdown-author
 description: Use when writing or editing markdown to proactively enforce linting rules and spelling standards, preventing violations before commit.
+metadata:
+  type: Implementation
+  priority: P4
 ---
 
 # Markdown Author

--- a/skills/monorepo-orchestration-setup/SKILL.md
+++ b/skills/monorepo-orchestration-setup/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: monorepo-orchestration-setup
 description: Use when setting up or orchestrating monorepos with build tools like Nx, Turborepo, or Lerna. Covers workspace configuration, task pipelines, dependency graph management, caching strategies, and CI/CD integration patterns.
+metadata:
+  type: Platform
+  priority: P2
 ---
 
 # Monorepo Orchestration Setup

--- a/skills/observability-logging-baseline/SKILL.md
+++ b/skills/observability-logging-baseline/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: observability-logging-baseline
 description: Use when establishing observability foundations including structured logging, metrics, and distributed tracing using OpenTelemetry standards.
+metadata:
+  type: Implementation
+  priority: P2
 ---
 
 ## Overview

--- a/skills/pair-programming/SKILL.md
+++ b/skills/pair-programming/SKILL.md
@@ -5,6 +5,9 @@ description: |
   implementer and human as supervisor. Enables high autonomy between checkpoints
   with automated review loops before human review.
 model: balanced # Implementation work → Sonnet 4.5, GPT-5.1
+metadata:
+  type: Process
+  priority: P3
 ---
 
 # Pair Programming

--- a/skills/persona-switching/SKILL.md
+++ b/skills/persona-switching/SKILL.md
@@ -5,8 +5,8 @@ compatibility: Requires bash/zsh shell, GPG, and gh CLI
 requires:
   - superpowers:verification-before-completion
 metadata:
-  type: Setup + Runtime
-  priority: P2 (Consistency & Governance)
+  type: Platform
+  priority: P3
 ---
 
 # Persona-Switching

--- a/skills/process-skill-router/SKILL.md
+++ b/skills/process-skill-router/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: process-skill-router
 description: Route agents to the correct process skill based on context and preconditions. Use when uncertain which process skill applies or when starting new work.
+metadata:
+  type: Process
+  priority: P3
 ---
 
 # Process Skill Router

--- a/skills/release-tagging-plan/SKILL.md
+++ b/skills/release-tagging-plan/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: release-tagging-plan
 description: Use when planning release versions, creating tags, or establishing versioning strategies. Applies semantic versioning principles, manages pre-release workflows, handles hotfix lineage, and creates release cadence plans with proper changelog documentation.
+metadata:
+  type: Process
+  priority: P2
 ---
 
 # Release Tagging Plan

--- a/skills/repo-best-practices-bootstrap/SKILL.md
+++ b/skills/repo-best-practices-bootstrap/SKILL.md
@@ -6,7 +6,7 @@ description: |
   documentation, and agent enablement.
 metadata:
   type: Platform
-  priority: P0
+  priority: P2
 ---
 
 # Repo Best Practices Bootstrap

--- a/skills/requirements-gathering/SKILL.md
+++ b/skills/requirements-gathering/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: requirements-gathering
 description: Gather requirements through interactive questions and create work items without committing design documents
+metadata:
+  type: Process
+  priority: P3
 ---
 
 # Requirements Gathering

--- a/skills/runtime-tooling-validation/SKILL.md
+++ b/skills/runtime-tooling-validation/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: runtime-tooling-validation
 description: Use when setting up a development environment, cloning a repository, or before running builds and tests. Validates runtime dependencies, SDK versions, environment variables, and service connectivity before attempting operations that would fail without them.
+metadata:
+  type: Platform
+  priority: P1
 ---
 
 # Runtime Tooling Validation

--- a/skills/safe-brownfield-refactor/SKILL.md
+++ b/skills/safe-brownfield-refactor/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: safe-brownfield-refactor
 description: Use when refactoring legacy codebases, introducing changes to systems without comprehensive test coverage, or modernising established production systems. Provides risk-managed strategies for incremental improvement.
+metadata:
+  type: Process
+  priority: P3
 ---
 
 # Safe Brownfield Refactor

--- a/skills/scoped-colocation/SKILL.md
+++ b/skills/scoped-colocation/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: scoped-colocation
 description: Use when organizing code structure, creating new features, or reviewing file placement to keep related code together by scope and reduce cognitive load.
+metadata:
+  type: Implementation
+  priority: P2
 ---
 
 # Scoped Colocation

--- a/skills/static-analysis-security/SKILL.md
+++ b/skills/static-analysis-security/SKILL.md
@@ -3,7 +3,7 @@ name: static-analysis-security
 description: Use when implementing or configuring static analysis for security, including SAST tools, security linting, secrets detection, and vulnerability threshold management. Covers tool selection, CI integration, IDE setup, and suppression policies.
 metadata:
   type: Quality
-  priority: P1
+  priority: P0
 ---
 
 # Static Analysis Security

--- a/skills/technical-debt-prioritisation/SKILL.md
+++ b/skills/technical-debt-prioritisation/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: technical-debt-prioritisation
 description: Use when facing technical debt backlog requiring systematic prioritisation. Applies three-dimensional scoring (impact, risk, effort), categorises by debt type, identifies quick wins, and creates multi-horizon roadmaps for evidence-based remediation planning.
+metadata:
+  type: Process
+  priority: P3
 ---
 
 # Technical Debt Prioritisation

--- a/skills/testcontainers-integration-tests/SKILL.md
+++ b/skills/testcontainers-integration-tests/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: testcontainers-integration-tests
 description: Use when integration tests require real infrastructure (database, message queue, cache) or when mocking infrastructure is insufficient. Defines container lifecycle, test isolation, and performance optimization for Testcontainers-based testing.
+metadata:
+  type: Implementation
+  priority: P1
 ---
 
 # Testcontainers Integration Tests

--- a/skills/testing-strategy-agnostic/SKILL.md
+++ b/skills/testing-strategy-agnostic/SKILL.md
@@ -2,7 +2,7 @@
 name: testing-strategy-agnostic
 description: Use when defining, reviewing, or improving a testing strategy in any stack; focuses on layered testing, incremental enforcement, data safety, architecture enforcement, contract versioning, and observability.
 metadata:
-  type: Quality
+  type: Implementation
   priority: P1
 ---
 

--- a/skills/testing-strategy-dotnet/SKILL.md
+++ b/skills/testing-strategy-dotnet/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: testing-strategy-dotnet
 description: Use when implementing or reviewing a .NET testing approach with unit, system, and E2E tiers, BDD practices, architecture enforcement, contract versioning, and strict observability rules.
+metadata:
+  type: Implementation
+  priority: P1
 ---
 
 # Testing Strategy (.NET Opinionated)

--- a/skills/walking-skeleton-delivery/SKILL.md
+++ b/skills/walking-skeleton-delivery/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: walking-skeleton-delivery
 description: Use when starting new system or migration requiring minimal end-to-end slice for architecture validation. Defines simplest E2E flow in BDD format, establishes deployment pipeline, and validates technical decisions before full build-out.
+metadata:
+  type: Process
+  priority: P3
 ---
 
 # Walking Skeleton Delivery


### PR DESCRIPTION
## Summary

- Added `metadata.type` and `metadata.priority` fields to 51 skills
- Follows SKILL-FORMAT.md specification for skill categorization
- Enables machine-readable skill prioritization and conflict resolution

## Priority Distribution

| Priority | Category | Count | Examples |
|----------|----------|-------|----------|
| P0 | Safety & Integrity | 4 | security-processes, deployment-provenance |
| P1 | Quality & Correctness | 12 | testing-strategy-*, architecture-testing |
| P2 | Consistency & Governance | 24 | dotnet-*, ci-cd-conformance |
| P3 | Delivery & Flow | 10 | pair-programming, finishing-a-development-branch |
| P4 | Optimization & Convenience | 2 | markdown-author, local-dev-experience |

## Type Distribution

| Type | Count | Examples |
|------|-------|----------|
| Process | 14 | issue-driven-delivery, skills-first-workflow |
| Platform | 12 | ci-cd-conformance, repo-best-practices-bootstrap |
| Quality | 6 | broken-window, security-processes |
| Implementation | 23 | dotnet-*, testing-strategy-* |

## Issues

- Closes #394

## Test Plan

- [x] `npm run validate:skills` - All 55 skills pass ([evidence](https://github.com/mcj-coder/development-skills/pull/395/checks))
- [x] `npm run lint` - All checks pass ([evidence](https://github.com/mcj-coder/development-skills/pull/395/checks))

🤖 Generated with [Claude Code](https://claude.com/claude-code)